### PR TITLE
Add custom_frame_mappings tutorial and optimizations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,7 @@ class CustomGalleryExampleSortKey:
                 "approximate_mode.py",
                 "sampling.py",
                 "parallel_decoding.py",
+                "custom_frame_mappings.py",
             ]
         else:
             assert "examples/encoding" in self.src_dir

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -24,7 +24,7 @@ This makes it ideal for workflows where:
 # %%
 # First, some boilerplate: we'll download a short video from the web, and
 # use ffmpeg to create a longer version by repeating it multiple times. We'll end up
-# with two videos: a short one of approximately 14 seconds and a long one of about 14 minutes.
+# with two videos: a short one of approximately 14 seconds and a long one of about 12 minutes.
 # You can ignore this part and skip below to :ref:`frame_mappings_creation`.
 
 import tempfile
@@ -48,7 +48,7 @@ with open(short_video_path, 'wb') as f:
 long_video_path = Path(temp_dir) / "long_video.mp4"
 ffmpeg_command = [
     "ffmpeg",
-    "-stream_loop", "80",  # repeat video 80 times to get a ~18 min video
+    "-stream_loop", "50",  # repeat video 50 times to get a ~12 min video
     "-i", f"{short_video_path}",
     "-c", "copy",
     f"{long_video_path}"
@@ -83,7 +83,7 @@ import json
 # Lets define a simple function to run ffprobe on a video's first stream index, then writes the results in output_json_path.
 def generate_frame_mappings(video_path, output_json_path, stream_index):
     ffprobe_cmd = ["ffprobe", "-i", f"{video_path}", "-select_streams", f"{stream_index}", "-show_frames", "-show_entries", "frame=pts,duration,key_frame", "-of", "json"]
-    print(f"Running ffprobe:\n{' '.join(ffprobe_cmd)}")
+    print(f"Running ffprobe:\n{' '.join(ffprobe_cmd)}\n")
     ffprobe_result = subprocess.run(ffprobe_cmd, check=True, capture_output=True, text=True)
     with open(output_json_path, "w") as f:
         f.write(ffprobe_result.stdout)

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -211,12 +211,11 @@ print("Frame seeking is the same for this video!")
 # ------------------------
 #
 # - For fastest decoding when speed is more important than exact seeking accuracy,
-# "approximate" mode is recommended.
+#   "approximate" mode is recommended.
 #
 # - For exact frame seeking, custom frame mappings will benefit workflows where the
 #   same videos are decoded repeatedly, and some preprocessing work can be done.
 #
 # - For exact frame seeking without preprocessing, use "exact" mode.
-#
 
 # %%

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -134,7 +134,7 @@ def decode_frames_from_n_videos(video_path, seek_mode = "exact", custom_frame_ma
             seek_mode=seek_mode,
             custom_frame_mappings=custom_frame_mappings
         )
-    decoder.get_frames_in_range(start=0, stop=10)
+        decoder.get_frames_in_range(start=0, stop=10)
 
 
 for video_path, json_path in ((short_video_path, short_json_path), (long_video_path, long_json_path)):

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -11,49 +11,59 @@ Decoding with custom_frame_mappings: Performance and accuracy comparison
 
 In this example, we will describe the ``custom_frame_mappings`` parameter of the
 :class:`~torchcodec.decoders.VideoDecoder` class.
+
+This parameter allows you to provide pre-computed frame mapping information to
+speed up :class:`~torchcodec.decoders.VideoDecoder` instantiation, while
+maintaining the frame seeking accuracy of ``seek_mode="exact"``.
+
+This makes it ideal for workflows where:
+    1. accuracy is critical, so ``seek_mode="approximate"`` cannot be used
+    2. the videos can be preprocessed once and then decoded many times.
 """
 
 # %%
-# Create an HD video using ffmpeg and use the ffmpeg CLI to repeat it 10 times
-# to get two videos: a short video of approximately 30 seconds and a long one of about 10 mins.
+# First, let's set up our test videos: we'll download a short video and
+# use ffmpeg to create a longer version by repeating it multiple times.
 
 import tempfile
 from pathlib import Path
 import subprocess
-from torchcodec.decoders import VideoDecoder
+import requests
+
+url = "https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4"
+response = requests.get(url, headers={"User-Agent": ""})
+if response.status_code != 200:
+    raise RuntimeError(f"Failed to download video. {response.status_code = }.")
 
 temp_dir = tempfile.mkdtemp()
 short_video_path = Path(temp_dir) / "short_video.mp4"
-
-ffmpeg_generate_video_command = [
-    "ffmpeg",
-    "-y",
-    "-f", "lavfi",
-    "-i", "mandelbrot=s=1920x1080",
-    "-t", "30",
-    "-c:v", "h264",
-    "-r", "60",
-    "-g", "600",
-    "-pix_fmt", "yuv420p",
-    f"{short_video_path}"
-]
-subprocess.run(ffmpeg_generate_video_command)
+with open(short_video_path, 'wb') as f:
+    for chunk in response.iter_content():
+        f.write(chunk)
 
 long_video_path = Path(temp_dir) / "long_video.mp4"
 ffmpeg_command = [
     "ffmpeg",
-    "-stream_loop", "20",  # repeat video 20 times to get a 10 min video
+    "-stream_loop", "3",  # repeat video 3 times to get a ~13 min video
     "-i", f"{short_video_path}",
     "-c", "copy",
     f"{long_video_path}"
 ]
-subprocess.run(ffmpeg_command)
+subprocess.run(ffmpeg_command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
+from torchcodec.decoders import VideoDecoder
 print(f"Short video duration: {VideoDecoder(short_video_path).metadata.duration_seconds} seconds")
 print(f"Long video duration: {VideoDecoder(long_video_path).metadata.duration_seconds / 60} minutes")
 
 # %%
-# Preprocessing step to create frame mappings for the videos using ffprobe.
+# .. _frame_mappings_creation:
+#
+# Creating custom frame mappings with ffprobe
+# --------------------------------------------
+#
+# The key to using custom frame mappings is preprocessing your videos to extract
+# frame timing information, and whether or not a frame is a keyframe information.
+# We use ffprobe to generate JSON files containing this metadata.
 
 from pathlib import Path
 import subprocess
@@ -62,7 +72,6 @@ from time import perf_counter_ns
 
 stream_index = 0
 
-temp_dir = tempfile.mkdtemp()
 long_json_path = Path(temp_dir) / "long_custom_frame_mappings.json"
 short_json_path = Path(temp_dir) / "short_custom_frame_mappings.json"
 
@@ -79,8 +88,14 @@ with open(short_json_path, "w") as f:
     print(f"Wrote {len(ffprobe_result.stdout)} characters to {short_json_path}")
 
 # %%
-# Define benchmarking function. When a file_like object is passed in, its necessary to seek
-# to the beginning of the file before reading it in the next iteration.
+# .. _perf_creation:
+#
+# Performance: ``VideoDecoder`` creation with custom frame mappings
+# ------------------------------------------------------------------
+#
+# Let's define a benchmarking function to measure performance. Note that when using
+# file-like objects for custom_frame_mappings, we need to seek back to the beginning
+# between iterations since the JSON data is consumed during VideoDecoder creation.
 
 import torch
 
@@ -106,16 +121,15 @@ def bench(f, file_like=False, average_over=50, warmup=2, **f_kwargs):
     print(f"{med = :.2f}ms +- {std:.2f}")
 
 # %%
-# Compare performance of initializing VideoDecoder with custom_frame_mappings vs exact seek_mode
+# Now let's compare the performance of creating VideoDecoder objects with custom
+# frame mappings versus the exact seek mode. You'll see that custom
+# frame mappings provide significant speedups, especially for longer videos.
 
 
 for video_path, json_path in ((short_video_path, short_json_path), (long_video_path, long_json_path)):
     print(f"Running benchmarks on {Path(video_path).name}")
-    print("Creating a VideoDecoder object with custom_frame_mappings JSON str from file:")
-    with open(json_path, "r") as f:
-        bench(VideoDecoder, source=video_path, stream_index=stream_index, custom_frame_mappings=(f.read()))
 
-    print("Creating a VideoDecoder object with custom_frame_mappings from filelike:")
+    print("Creating a VideoDecoder object with custom_frame_mappings:")
     with open(json_path, "r") as f:
         bench(VideoDecoder, file_like=True, source=video_path, stream_index=stream_index, custom_frame_mappings=f)
 
@@ -124,7 +138,12 @@ for video_path, json_path in ((short_video_path, short_json_path), (long_video_p
     bench(VideoDecoder, source=video_path, stream_index=stream_index, seek_mode="exact")
 
 # %%
-# Decode frames with custom_frame_mappings vs exact seek_mode
+# Performance: Frame decoding with custom frame mappings
+# --------------------------------------------------------
+#
+# The performance benefits extend to frame decoding operations as well, since
+# each decoding workflow typically involves creating a VideoDecoder instance.
+# Let's compare frame decoding performance between the two approaches.
 
 
 def decode_frames(video_path, seek_mode = "exact", custom_frame_mappings = None):
@@ -140,38 +159,59 @@ for video_path, json_path in ((short_video_path, short_json_path), (long_video_p
     print(f"Running benchmarks on {Path(video_path).name}")
     print("Decoding frames with custom_frame_mappings JSON str from file:")
     with open(json_path, "r") as f:
-        bench(decode_frames, video_path=video_path, custom_frame_mappings=(f.read()))
+        bench(decode_frames, file_like=True, video_path=video_path, custom_frame_mappings=f)
 
     print("Decoding frames with seek_mode='exact':")
     bench(decode_frames, video_path=video_path, seek_mode="exact")
 
 # %%
-# Compare frame accuracy with custom_frame_mappings vs exact seek_mode
-video_path = short_video_path
-json_path = short_json_path
+# Accuracy: High accuracy frame seeking with custom frame mappings
+# -----------------------------------------------------------
+#
+# The main advantage of using custom frame mappings over approximate mode is that
+# frame seeking accuracy is as high as exact mode.
+
+video_path = long_video_path
+json_path = long_json_path
 with open(json_path, "r") as f:
-    custom_frame_mappings = f.read()
     custom_frame_mappings_decoder = VideoDecoder(
         source=video_path,
-        custom_frame_mappings=custom_frame_mappings
+        custom_frame_mappings=f,
+        stream_index=0
     )
 
-exact_decoder = VideoDecoder(short_video_path, seek_mode="exact")
-approx_decoder = VideoDecoder(short_video_path, seek_mode="approximate")
+exact_decoder = VideoDecoder(video_path, seek_mode="exact", stream_index=0)
+approx_decoder = VideoDecoder(video_path, seek_mode="approximate", stream_index=0)
 
-print("Metadata of short video with custom_frame_mappings:")
-print(custom_frame_mappings_decoder.metadata)
-print("Metadata of short video with seek_mode='exact':")
-print(exact_decoder.metadata)
-print("Metadata of short video with seek_mode='approximate':")
-print(approx_decoder.metadata)
-
-for i in range(len(approx_decoder)):
+print("Comparing frames between exact seek mode decoder and custom_frame_mappings decoder:")
+for i in range(len(exact_decoder)):
     torch.testing.assert_close(
-        approx_decoder.get_frame_at(i).data,
+        exact_decoder.get_frame_at(i).data,
         custom_frame_mappings_decoder.get_frame_at(i).data,
         atol=0, rtol=0,
     )
 print("Frame seeking is the same for this video!")
+
+# %%
+# How do custom_frame_mappings help?
+# ----------------------------------
+#
+# Custom frame mappings contain the same frame index information
+# that would normally be computed during the :term:`scan` operation in exact mode.
+# (frame presentation timestamps (PTS), durations, and keyframe indicators)
+# By providing this information to the :class:`~torchcodec.decoders.VideoDecoder`
+# as a JSON, it eliminates the need for the expensive scan while preserving all the
+# accuracy benefits.
+#
+# Which approach should I use?
+# -----------------------------
+#
+# - For fastest decoding, "approximate" mode is strongly recommended.
+#
+# - For exact frame seeking, custom frame mappings will benefit workflows where the
+#   same videos are decoded repeatedly, and some preprocessing work can be done.
+#
+# - For exact frame seeking without preprocessing, use "exact" mode.
+#
 
 # %%

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -1,0 +1,182 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+========================================================================
+Decoding with custom_frame_mappings: Performance and accuracy comparison
+========================================================================
+
+In this example, we will describe the ``custom_frame_mappings`` parameter of the
+:class:`~torchcodec.decoders.VideoDecoder` class.
+"""
+
+# %%
+# Create an HD video using ffmpeg and use the ffmpeg CLI to repeat it 100 times.
+# To get videos: a short video of approximately 30 seconds and a long one of about 22 mins.
+
+
+import tempfile
+from pathlib import Path
+import subprocess
+
+temp_dir = tempfile.mkdtemp()
+short_video_path = Path(temp_dir) / "short_video.mp4"
+
+ffmpeg_generate_video_command = [
+    "ffmpeg",
+    "-y",
+    "-f", "lavfi",
+    "-i", "mandelbrot=s=1920x1080",
+    "-t", "30",
+    "-c:v", "h264",
+    "-r", "60",
+    "-g", "600",
+    "-pix_fmt", "yuv420p",
+    f"{short_video_path}"
+]
+subprocess.run(ffmpeg_generate_video_command)
+
+long_video_path = Path(temp_dir) / "long_video.mp4"
+ffmpeg_command = [
+    "ffmpeg",
+    "-stream_loop", "20",  # repeat video 20 times to get a ~20 min video
+    "-i", f"{short_video_path}",
+    "-c", "copy",
+    f"{long_video_path}"
+]
+subprocess.run(ffmpeg_command)
+from torchcodec.decoders import VideoDecoder
+test_decoder = VideoDecoder(short_video_path)
+print(f"Short video duration: {test_decoder.metadata.duration_seconds} seconds")
+print(f"Long video duration: {VideoDecoder(long_video_path).metadata.duration_seconds / 60} minutes")
+
+# %%
+# Preprocessing step
+from pathlib import Path
+import subprocess
+import tempfile
+from time import perf_counter_ns
+
+stream_index = 0
+
+temp_dir = tempfile.mkdtemp()
+long_json_path = Path(temp_dir) / "long_custom_frame_mappings.json"
+short_json_path = Path(temp_dir) / "short_custom_frame_mappings.json"
+
+ffprobe_cmd = ["ffprobe", "-i", f"{long_video_path}", "-select_streams", f"{stream_index}", "-show_frames", "-show_entries", "frame=pts,duration,key_frame", "-of", "json"]
+ffprobe_result = subprocess.run(ffprobe_cmd, check=True, capture_output=True, text=True)
+with open(long_json_path, "w") as f:
+    f.write(ffprobe_result.stdout)
+    print(f"Wrote {len(ffprobe_result.stdout)} characters to {long_json_path}")
+
+ffprobe_cmd = ["ffprobe", "-i", f"{short_video_path}", "-select_streams", f"{stream_index}", "-show_frames", "-show_entries", "frame=pts,duration,key_frame", "-of", "json"]
+ffprobe_result = subprocess.run(ffprobe_cmd, check=True, capture_output=True, text=True)
+with open(short_json_path, "w") as f:
+    f.write(ffprobe_result.stdout)
+    print(f"Wrote {len(ffprobe_result.stdout)} characters to {short_json_path}")
+
+# %%
+# Define benchmarking function
+
+from torchcodec import samplers
+from torchcodec.decoders._video_decoder import VideoDecoder
+import torch
+
+
+def bench(f, file_like=False, average_over=50, warmup=2, **f_kwargs):
+    for _ in range(warmup):
+        f(**f_kwargs)
+        if file_like:
+            f_kwargs["custom_frame_mappings"].seek(0)
+
+    times = []
+    for _ in range(average_over):
+        start = perf_counter_ns()
+        f(**f_kwargs)
+        end = perf_counter_ns()
+        times.append(end - start)
+        if file_like:
+            f_kwargs["custom_frame_mappings"].seek(0)
+
+    times = torch.tensor(times) * 1e-6  # ns to ms
+    std = times.std().item()
+    med = times.median().item()
+    print(f"{med = :.2f}ms +- {std:.2f}")
+
+# %%
+# Compare performance of initializing VideoDecoder with custom_frame_mappings vs seek_modes
+
+
+for video_path, json_path in ((short_video_path, short_json_path), (long_video_path, long_json_path)):
+    print(f"Running benchmarks on {Path(video_path).name}")
+    print("Creating a VideoDecoder object with custom_frame_mappings JSON str from file:")
+    with open(json_path, "r") as f:
+        bench(VideoDecoder, source=video_path, stream_index=stream_index, custom_frame_mappings=(f.read()))
+
+    print("Creating a VideoDecoder object with custom_frame_mappings from filelike:")
+    with open(json_path, "r") as f:
+        bench(VideoDecoder, file_like=True, source=video_path, stream_index=stream_index, custom_frame_mappings=f)
+
+    # Compare against seek_modes
+    print("Creating a VideoDecoder object with seek_mode='exact':")
+    bench(VideoDecoder, source=video_path, stream_index=stream_index, seek_mode="exact")
+
+# %%
+# Decode entire videos with custom_frame_mappings vs seek_modes
+
+from torchcodec.decoders._video_decoder import VideoDecoder
+
+
+def decode_frames(video_path, seek_mode = "exact", custom_frame_mappings = None):
+    decoder = VideoDecoder(
+        source=video_path,
+        seek_mode=seek_mode,
+        custom_frame_mappings=custom_frame_mappings
+    )
+    decoder.get_frames_in_range(start=0, stop=100)
+
+
+for video_path, json_path in ((short_video_path, short_json_path), (long_video_path, long_json_path)):
+    print(f"Running benchmarks on {Path(video_path).name}")
+    print("Decoding frames with custom_frame_mappings JSON str from file:")
+    with open(json_path, "r") as f:
+        bench(decode_frames, video_path=video_path, custom_frame_mappings=(f.read()))
+
+    print("Creating a VideoDecoder object with custom_frame_mappings from filelike:")
+    with open(json_path, "r") as f:
+        bench(decode_frames, file_like=True, video_path=video_path, custom_frame_mappings=f)
+
+    # Compare against seek_modes
+    print("Decoding frames with seek_mode='exact':")
+    bench(decode_frames, video_path=video_path, seek_mode="exact")
+
+# %%
+# Compare performance of sampling clips with custom_frame_mappings vs seek_modes
+
+
+def sample_clips(video_path, seek_mode = "exact", custom_frame_mappings = None):
+    return samplers.clips_at_random_indices(
+        decoder=VideoDecoder(
+            source=video_path,
+            seek_mode=seek_mode,
+            custom_frame_mappings=custom_frame_mappings
+        ),
+        num_clips=5,
+        num_frames_per_clip=2,
+    )
+
+
+for video_path, json_path in ((short_video_path, short_json_path), (long_video_path, long_json_path)):
+    print(f"Running benchmarks on {Path(video_path).name}")
+    print("Sampling clips with custom_frame_mappings:")
+    with open(json_path, "r") as f:
+        mappings = f.read()
+        bench(sample_clips, file_like=False, video_path=video_path, custom_frame_mappings=mappings)
+
+    print("Sampling clips with seek_mode='exact':")
+    bench(sample_clips, video_path=video_path, seek_mode="exact")
+
+# %%

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -81,12 +81,12 @@ stream_index = 0
 long_json_path = Path(temp_dir) / "long_custom_frame_mappings.json"
 short_json_path = Path(temp_dir) / "short_custom_frame_mappings.json"
 
-ffprobe_cmd = ["ffprobe", "-i", f"{long_video_path}", "-select_streams", f"{stream_index}", "-show_frames", "-show_entries", "frame=pkt_pts,pkt_duration,key_frame", "-of", "json"]
+ffprobe_cmd = ["ffprobe", "-i", f"{long_video_path}", "-select_streams", f"v:{stream_index}", "-show_frames", "-show_entries", "frame=pkt_pts,pkt_duration,key_frame", "-of", "json"]
 ffprobe_result = subprocess.run(ffprobe_cmd, check=True, capture_output=True, text=True)
 with open(long_json_path, "w") as f:
     f.write(ffprobe_result.stdout)
 
-ffprobe_cmd = ["ffprobe", "-i", f"{short_video_path}", "-select_streams", f"{stream_index}", "-show_frames", "-show_entries", "frame=pkt_pts,pkt_duration,key_frame", "-of", "json"]
+ffprobe_cmd = ["ffprobe", "-i", f"{short_video_path}", "-select_streams", f"v:{stream_index}", "-show_frames", "-show_entries", "frame=pkt_pts,pkt_duration,key_frame", "-of", "json"]
 ffprobe_result = subprocess.run(ffprobe_cmd, check=True, capture_output=True, text=True)
 with open(short_json_path, "w") as f:
     f.write(ffprobe_result.stdout)

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -59,7 +59,7 @@ print(f"Long video duration: {VideoDecoder(long_video_path).metadata.duration_se
 # .. _frame_mappings_creation:
 #
 # Creating custom frame mappings with ffprobe
-# --------------------------------------------
+# -------------------------------------------
 #
 # The key to using custom frame mappings is preprocessing your videos to extract
 # frame timing information, and whether or not a frame is a keyframe information.
@@ -91,7 +91,7 @@ with open(short_json_path, "w") as f:
 # .. _perf_creation:
 #
 # Performance: ``VideoDecoder`` creation with custom frame mappings
-# ------------------------------------------------------------------
+# -----------------------------------------------------------------
 #
 # Let's define a benchmarking function to measure performance. Note that when using
 # file-like objects for custom_frame_mappings, we need to seek back to the beginning
@@ -139,7 +139,7 @@ for video_path, json_path in ((short_video_path, short_json_path), (long_video_p
 
 # %%
 # Performance: Frame decoding with custom frame mappings
-# --------------------------------------------------------
+# ------------------------------------------------------
 #
 # The performance benefits extend to frame decoding operations as well, since
 # each decoding workflow typically involves creating a VideoDecoder instance.
@@ -166,7 +166,7 @@ for video_path, json_path in ((short_video_path, short_json_path), (long_video_p
 
 # %%
 # Accuracy: High accuracy frame seeking with custom frame mappings
-# -----------------------------------------------------------
+# ----------------------------------------------------------------
 #
 # The main advantage of using custom frame mappings over approximate mode is that
 # frame seeking accuracy is as high as exact mode.
@@ -204,7 +204,7 @@ print("Frame seeking is the same for this video!")
 # accuracy benefits.
 #
 # Which approach should I use?
-# -----------------------------
+# ----------------------------
 #
 # - For fastest decoding, "approximate" mode is strongly recommended.
 #

--- a/examples/decoding/custom_frame_mappings.py
+++ b/examples/decoding/custom_frame_mappings.py
@@ -81,12 +81,12 @@ stream_index = 0
 long_json_path = Path(temp_dir) / "long_custom_frame_mappings.json"
 short_json_path = Path(temp_dir) / "short_custom_frame_mappings.json"
 
-ffprobe_cmd = ["ffprobe", "-i", f"{long_video_path}", "-select_streams", f"v:{stream_index}", "-show_frames", "-show_entries", "frame=pkt_pts,pkt_duration,key_frame", "-of", "json"]
+ffprobe_cmd = ["ffprobe", "-i", f"{long_video_path}", "-select_streams", f"{stream_index}", "-show_frames", "-show_entries", "frame=pts,duration,key_frame", "-of", "json"]
 ffprobe_result = subprocess.run(ffprobe_cmd, check=True, capture_output=True, text=True)
 with open(long_json_path, "w") as f:
     f.write(ffprobe_result.stdout)
 
-ffprobe_cmd = ["ffprobe", "-i", f"{short_video_path}", "-select_streams", f"v:{stream_index}", "-show_frames", "-show_entries", "frame=pkt_pts,pkt_duration,key_frame", "-of", "json"]
+ffprobe_cmd = ["ffprobe", "-i", f"{short_video_path}", "-select_streams", f"{stream_index}", "-show_frames", "-show_entries", "frame=pts,duration,key_frame", "-of", "json"]
 ffprobe_result = subprocess.run(ffprobe_cmd, check=True, capture_output=True, text=True)
 with open(short_json_path, "w") as f:
     f.write(ffprobe_result.stdout)

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -490,6 +490,7 @@ void SingleStreamDecoder::addVideoStream(
 
   auto& streamInfo = streamInfos_[activeStreamIndex_];
   streamInfo.videoStreamOptions = videoStreamOptions;
+  streamInfo.timeBase = formatContext_->streams[activeStreamIndex_]->time_base;
 
   streamMetadata.width = streamInfo.codecContext->width;
   streamMetadata.height = streamInfo.codecContext->height;
@@ -501,7 +502,7 @@ void SingleStreamDecoder::addVideoStream(
         customFrameMappings.has_value(),
         "Missing frame mappings when custom_frame_mappings seek mode is set.");
     readCustomFrameMappingsUpdateMetadataAndIndex(
-        streamIndex, customFrameMappings.value());
+        activeStreamIndex_, customFrameMappings.value());
   }
 }
 

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -499,7 +499,6 @@ void SingleStreamDecoder::addVideoStream(
 
   auto& streamInfo = streamInfos_[activeStreamIndex_];
   streamInfo.videoStreamOptions = videoStreamOptions;
-  streamInfo.timeBase = formatContext_->streams[activeStreamIndex_]->time_base;
 
   streamMetadata.width = streamInfo.codecContext->width;
   streamMetadata.height = streamInfo.codecContext->height;

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -332,9 +332,10 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
           is_key_frame.size(0) == duration.size(0),
       "all_frames, is_key_frame, and duration from custom_frame_mappings were not same size.");
 
-  // Allocate vector using num frames to reduce reallocations
+  // Allocate vectors using num frames to reduce reallocations
   int64_t numFrames = all_frames.size(0);
   streamInfos_[streamIndex].allFrames.reserve(numFrames);
+  streamInfos_[streamIndex].keyFrames.reserve(numFrames);
   // Access tensor data directly rather than element wise to speed up loop below
   auto* pts_data = all_frames.data_ptr<int64_t>();
   auto* is_key_frame_data = is_key_frame.data_ptr<bool>();

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -322,6 +322,11 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
 void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
     int streamIndex,
     FrameMappings customFrameMappings) {
+  TORCH_CHECK(
+      customFrameMappings.all_frames.dtype() == torch::kLong &&
+          customFrameMappings.is_key_frame.dtype() == torch::kBool &&
+          customFrameMappings.duration.dtype() == torch::kLong,
+      "all_frames and duration tensors must be int64 dtype, and is_key_frame tensor must be a bool dtype.");
   const torch::Tensor& all_frames =
       customFrameMappings.all_frames.to(torch::kLong);
   const torch::Tensor& is_key_frame =

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -336,10 +336,10 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
   int64_t numFrames = all_frames.size(0);
   streamInfos_[streamIndex].allFrames.reserve(numFrames);
   streamInfos_[streamIndex].keyFrames.reserve(numFrames);
-  // Access tensor data directly rather than element wise to speed up loop below
-  auto* pts_data = all_frames.data_ptr<int64_t>();
-  auto* is_key_frame_data = is_key_frame.data_ptr<bool>();
-  auto* duration_data = duration.data_ptr<int64_t>();
+  // Use accessor to efficiently access tensor elements
+  auto pts_data = all_frames.accessor<int64_t, 1>();
+  auto is_key_frame_data = is_key_frame.accessor<bool, 1>();
+  auto duration_data = duration.accessor<int64_t, 1>();
 
   auto& streamMetadata = containerMetadata_.allStreamMetadata[streamIndex];
 

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -82,6 +82,8 @@ class VideoDecoder:
                 }
 
             Alternative field names "pkt_pts" and "pkt_duration" are also supported.
+            Read more about this parameter in:
+            :ref:`sphx_glr_generated_examples_decoding_custom_frame_mappings.py`
 
     Attributes:
         metadata (VideoStreamMetadata): Metadata of the video stream.
@@ -475,13 +477,15 @@ def _read_custom_frame_mappings(
             "Invalid custom frame mappings. The 'pts'/'pkt_pts', 'duration'/'pkt_duration', and 'key_frame' keys are required in the frame metadata."
         )
 
-    frame_data = [
-        (int(frame[pts_key]), frame["key_frame"], int(frame[duration_key]))
-        for frame in input_data["frames"]
-    ]
-    all_frames = torch.tensor([x[0] for x in frame_data], dtype=torch.int64)
-    is_key_frame = torch.tensor([x[1] for x in frame_data], dtype=torch.bool)
-    duration = torch.tensor([x[2] for x in frame_data], dtype=torch.int64)
+    all_frames = torch.tensor(
+        [int(frame[pts_key]) for frame in input_data["frames"]], dtype=torch.int64
+    )
+    is_key_frame = torch.tensor(
+        [int(frame["key_frame"]) for frame in input_data["frames"]], dtype=torch.bool
+    )
+    duration = torch.tensor(
+        [int(frame[duration_key]) for frame in input_data["frames"]], dtype=torch.int64
+    )
     if not (len(all_frames) == len(is_key_frame) == len(duration)):
         raise ValueError("Mismatched lengths in frame index data")
     return all_frames, is_key_frame, duration

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -476,10 +476,12 @@ def _read_custom_frame_mappings(
         )
 
     frame_data = [
-        (float(frame[pts_key]), frame["key_frame"], float(frame[duration_key]))
+        (int(frame[pts_key]), frame["key_frame"], int(frame[duration_key]))
         for frame in input_data["frames"]
     ]
-    all_frames, is_key_frame, duration = map(torch.tensor, zip(*frame_data))
+    all_frames = torch.tensor([x[0] for x in frame_data], dtype=torch.int64)
+    is_key_frame = torch.tensor([x[1] for x in frame_data], dtype=torch.bool)
+    duration = torch.tensor([x[2] for x in frame_data], dtype=torch.int64)
     if not (len(all_frames) == len(is_key_frame) == len(duration)):
         raise ValueError("Mismatched lengths in frame index data")
     return all_frames, is_key_frame, duration

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -487,27 +487,41 @@ class TestVideoDecoderOps:
         reason="ffprobe not available internally",
     )
     def test_seek_mode_custom_frame_mappings_fails(self):
-        decoder = create_from_file(
-            str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
-        )
         with pytest.raises(
             RuntimeError,
             match="Missing frame mappings when custom_frame_mappings seek mode is set.",
         ):
+            decoder = create_from_file(
+                str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
+            )
             add_video_stream(decoder, stream_index=0, custom_frame_mappings=None)
 
-        decoder = create_from_file(
-            str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
-        )
-        different_lengths = (
-            torch.tensor([1, 2, 3]),
-            torch.tensor([1, 2]),
-            torch.tensor([1, 2, 3]),
-        )
+        with pytest.raises(
+            RuntimeError,
+            match="all_frames and duration tensors must be int64 dtype, and is_key_frame tensor must be a bool dtype.",
+        ):
+            decoder = create_from_file(
+                str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
+            )
+            wrong_types = (
+                torch.tensor([1.1, 2.2, 3.3]),
+                torch.tensor([1, 2]),
+                torch.tensor([1, 2, 3]),
+            )
+            add_video_stream(decoder, stream_index=0, custom_frame_mappings=wrong_types)
+
         with pytest.raises(
             RuntimeError,
             match="all_frames, is_key_frame, and duration from custom_frame_mappings were not same size.",
         ):
+            decoder = create_from_file(
+                str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
+            )
+            different_lengths = (
+                torch.tensor([1, 2, 3]),
+                torch.tensor([False, False]),
+                torch.tensor([1, 2, 3]),
+            )
             add_video_stream(
                 decoder, stream_index=0, custom_frame_mappings=different_lengths
             )


### PR DESCRIPTION
This PR adds the code that will become the `custom_frame_mappings` tutorial. 
Currently, 2 benchmarks are run using a short video (~3 minutes) and a long video (~13 minutes) :
* Initializing VideoDecoders 
* Decoding 10 frames from 10 videos

Additionally, some fixes / optimizations were added to `custom_frame_mappings` logic in `SingleStreamDecoder.cpp` to improve the performance.

The page takes 1 minute 22 seconds to execute.

Benchmark results: 
<details> 

#### Compare performance of initializing VideoDecoder with custom_frame_mappings vs seek_modes

Running benchmarks on short_video.mp4
Creating a VideoDecoder object with custom_frame_mappings:
med = 7.68ms +- 20.83
Creating a VideoDecoder object with seek_mode='exact':
med = 17.26ms +- 14.54

Running benchmarks on long_video.mp4
Creating a VideoDecoder object with custom_frame_mappings:
med = 23.70ms +- 3.39
Creating a VideoDecoder object with seek_mode='exact':
med = 60.47ms +- 7.30

#### Decode frames with custom_frame_mappings vs exact seek_mode

Running benchmarks on short_video.mp4
Decoding frames with custom_frame_mappings:
med = 34.21ms +- 11.42
Decoding frames with seek_mode='exact':
med = 39.69ms +- 3.37

Running benchmarks on long_video.mp4
Decoding frames with custom_frame_mappings:
med = 50.53ms +- 8.38
Decoding frames with seek_mode='exact':
med = 83.95ms +- 17.38

</details> 