### PR TITLE
Add `Packet.from_tensor` to build packets from raw data

### DIFF
--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -31,6 +31,7 @@ FFMPEG_OP_NAMES = frozenset(
         "get_json_metadata",
         "_blocks_create_demuxer",
         "_blocks_demuxer_next_packet",
+        "_blocks_packet_from_tensor",
         "_blocks_create_packet_decoder",
         "_blocks_packet_decoder_send_packet",
         "_blocks_packet_decoder_send_eof",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -96,6 +96,7 @@ _blocks_create_demuxer = torch.ops.torchcodec_ns._blocks_create_demuxer.default
 _blocks_demuxer_next_packet = (
     torch.ops.torchcodec_ns._blocks_demuxer_next_packet.default
 )
+_blocks_packet_from_tensor = torch.ops.torchcodec_ns._blocks_packet_from_tensor.default
 _blocks_create_packet_decoder = (
     torch.ops.torchcodec_ns._blocks_create_packet_decoder.default
 )

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -13,6 +13,8 @@
 #include <pybind11/pybind11.h>
 #pragma pop_macro("TORCH_TARGET_VERSION")
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <string>
 
 extern "C" {
@@ -76,6 +78,8 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def(
       "_blocks_create_demuxer(str filename, int? stream_index=None) -> Tensor");
   m.def("_blocks_demuxer_next_packet(Tensor(a!) demuxer) -> (Tensor, bool)");
+  m.def(
+      "_blocks_packet_from_tensor(Tensor data, *, int pts, int duration, bool is_key_frame) -> Tensor");
   m.def(
       "_blocks_create_packet_decoder(Tensor demuxer, *, int? num_threads=None, str device=\"cpu\", str device_variant=\"default\") -> Tensor");
   m.def(
@@ -669,10 +673,11 @@ void _add_video_stream(
       "None. This is a bug in TorchCodec, please report it.");
 
   std::optional<SingleStreamDecoder::FrameMappings> converted_mappings = has_pts
-      ? std::make_optional(SingleStreamDecoder::FrameMappings{
-            std::move(*custom_frame_mappings_pts),
-            std::move(*custom_frame_mappings_keyframe_indices),
-            std::move(*custom_frame_mappings_duration)})
+      ? std::make_optional(
+            SingleStreamDecoder::FrameMappings{
+                std::move(*custom_frame_mappings_pts),
+                std::move(*custom_frame_mappings_keyframe_indices),
+                std::move(*custom_frame_mappings_duration)})
       : std::nullopt;
   auto video_decoder = unwrap_tensor_to_get_decoder(decoder);
   video_decoder->add_video_stream(
@@ -855,6 +860,43 @@ OpsPacketOutput _blocks_demuxer_next_packet(torch::stable::Tensor& demuxer) {
     return std::make_tuple(torch::stable::full({1}, 0, kStableInt64), true);
   }
   return std::make_tuple(wrap_packet_pointer_to_tensor(packet), false);
+}
+
+// Build an owning packet handle from raw compressed bytes, for feeding a
+// PacketDecoder with packets that did not come from a Demuxer. pts and duration
+// are in the decoder's stream time_base units. dts is set to pts, which is only
+// correct for streams without frame reordering (no B-frames).
+torch::stable::Tensor _blocks_packet_from_tensor(
+    const torch::stable::Tensor& data,
+    int64_t pts,
+    int64_t duration,
+    bool is_key_frame) {
+  STD_TORCH_CHECK(data.is_contiguous(), "data must be contiguous");
+  STD_TORCH_CHECK(data.scalar_type() == kStableUInt8, "data must be kUInt8");
+  STD_TORCH_CHECK(data.numel() > 0, "data must not be empty");
+  STD_TORCH_CHECK(
+      data.numel() <= std::numeric_limits<int>::max(), "data is too large");
+
+  AVPacket* packet = av_packet_alloc();
+  STD_TORCH_CHECK(packet != nullptr, "Failed to allocate AVPacket");
+  // av_new_packet allocates data with the required AV_INPUT_BUFFER_PADDING_SIZE
+  // zero padding.
+  int status = av_new_packet(packet, static_cast<int>(data.numel()));
+  if (status != AVSUCCESS) {
+    av_packet_free(&packet);
+    STD_TORCH_CHECK(
+        false,
+        "av_new_packet failed: ",
+        get_ffmpeg_error_string_from_error_code(status));
+  }
+  std::memcpy(packet->data, data.const_data_ptr<uint8_t>(), data.numel());
+  packet->pts = pts;
+  packet->dts = pts;
+  packet->duration = duration;
+  if (is_key_frame) {
+    packet->flags |= AV_PKT_FLAG_KEY;
+  }
+  return wrap_packet_pointer_to_tensor(packet);
 }
 
 torch::stable::Tensor _blocks_create_packet_decoder(
@@ -1491,6 +1533,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl("get_frames_by_pts", TORCH_BOX(&get_frames_by_pts));
   m.impl(
       "_blocks_demuxer_next_packet", TORCH_BOX(&_blocks_demuxer_next_packet));
+  m.impl("_blocks_packet_from_tensor", TORCH_BOX(&_blocks_packet_from_tensor));
   m.impl(
       "_blocks_create_packet_decoder",
       TORCH_BOX(&_blocks_create_packet_decoder));

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -6,19 +6,68 @@
 
 from __future__ import annotations
 
+import warnings
+
 import torch
+
+from torchcodec._core.ops import _blocks_packet_from_tensor
 
 
 class Packet:
     """Opaque, thread-movable handle to a demuxed (compressed) packet.
 
-    Produced by :class:`Demuxer`, consumed by :class:`PacketDecoder`. It wraps a raw
-    pointer, so it is only valid within the process that created it (it cannot
-    cross a process boundary).
+    Produced by :class:`Demuxer` or built from raw bytes with
+    :meth:`from_tensor` / :meth:`from_bytes`, consumed by :class:`PacketDecoder`.
+
+    It wraps a raw pointer, so it is only valid within the process that created it.
     """
 
     def __init__(self, handle: torch.Tensor):
         self._handle = handle
+
+    @classmethod
+    def from_tensor(
+        cls,
+        data: torch.Tensor,
+        *,
+        pts: int,
+        duration: int,
+        is_key_frame: bool,
+    ) -> Packet:
+        """Build a :class:`Packet` from raw compressed bytes.
+
+        ``data`` is a 1D uint8 tensor holding the compressed packet payload.
+        ``pts`` and ``duration`` are expressed in the time base of the stream the
+        consuming :class:`PacketDecoder` was created for.
+        The packet's dts is set to ``pts``, which is only correct for streams without frame
+        reordering (no B-frames).
+        """
+        return cls(
+            _blocks_packet_from_tensor(
+                data, pts=pts, duration=duration, is_key_frame=is_key_frame
+            )
+        )
+
+    @classmethod
+    def from_bytes(
+        cls,
+        data: bytes,
+        *,
+        pts: int,
+        duration: int,
+        is_key_frame: bool,
+    ) -> Packet:
+        """Build a :class:`Packet` from raw compressed bytes.
+
+        Same as :meth:`from_tensor`, but takes the payload as ``bytes``.
+        """
+        with warnings.catch_warnings():
+            # Ignore warning stating that the underlying data buffer is non-writable.
+            warnings.filterwarnings("ignore", category=UserWarning)
+            buffer = torch.frombuffer(data, dtype=torch.uint8)
+        return cls.from_tensor(
+            buffer, pts=pts, duration=duration, is_key_frame=is_key_frame
+        )
 
 
 class DecodedFrame:

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -8,6 +8,7 @@ import concurrent.futures
 import contextlib
 import gc
 import queue
+import subprocess
 import threading
 from functools import partial
 
@@ -3158,7 +3159,6 @@ class TestAudioDecoder:
 
 
 class TestWavDecoder:
-
     def test_non_wav_file_raises_error(self):
         with pytest.raises(RuntimeError, match="Missing RIFF header"):
             WavDecoder(NASA_AUDIO.path)
@@ -3278,7 +3278,6 @@ class TestWavDecoder:
 
 
 class TestBlocks:
-
     def test_block_output_types(self):
         # Demuxer yields Packets, PacketDecoder yields DecodedFrames, and
         # ColorConverter yields Frames with the expected shape/dtype.
@@ -3300,6 +3299,67 @@ class TestBlocks:
                 assert frame.duration_seconds >= 0
 
         assert num_packets > 0
+
+    def test_packet_from_tensor(self, tmp_path):
+        # Packets built from bytes must decode to the exact frames as the demuxed packets they were copied from.
+        mjpeg_avi = str(tmp_path / "mjpeg.avi")
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", str(NASA_VIDEO.path), "-frames:v", "5"]
+            + ["-c:v", "mjpeg", "-q:v", "2", mjpeg_avi],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", mjpeg_avi, "-c:v", "copy", "-f", "image2"]
+            + [str(tmp_path / "pkt%03d.jpg")],
+            check=True,
+            capture_output=True,
+        )
+        payloads = [p.read_bytes() for p in sorted(tmp_path.glob("pkt*.jpg"))]
+        assert len(payloads) == 5
+
+        def decode_all(decoder, packets):
+            converter = ColorConverter()
+            decoded = [frame for packet in packets for frame in decoder.decode(packet)]
+            decoded += decoder.flush()
+            return [converter.convert(frame) for frame in decoded]
+
+        demuxer = Demuxer(mjpeg_avi)
+        reference = decode_all(PacketDecoder(demuxer), demuxer)
+
+        # The decoder still needs a Demuxer for its codec parameters, but the packets themselves are built from bytes.
+        packets = [
+            (
+                Packet.from_bytes(payload, pts=i, duration=1, is_key_frame=True)
+                if i % 2
+                else Packet.from_tensor(
+                    torch.frombuffer(bytearray(payload), dtype=torch.uint8),
+                    pts=i,
+                    duration=1,
+                    is_key_frame=True,
+                )
+            )
+            for i, payload in enumerate(payloads)
+        ]
+        from_bytes = decode_all(PacketDecoder(Demuxer(mjpeg_avi)), packets)
+
+        assert len(from_bytes) == len(reference)
+        for got, ref in zip(from_bytes, reference):
+            torch.testing.assert_close(got.data, ref.data, rtol=0, atol=0)
+        pts_list = [frame.pts_seconds for frame in from_bytes]
+        assert pts_list == sorted(pts_list) and len(set(pts_list)) == len(pts_list)
+
+        with pytest.raises(RuntimeError, match="data must be kUInt8"):
+            Packet.from_tensor(
+                torch.zeros(4, dtype=torch.float32),
+                pts=0,
+                duration=1,
+                is_key_frame=True,
+            )
+        with pytest.raises(RuntimeError, match="data must not be empty"):
+            Packet.from_tensor(
+                torch.empty(0, dtype=torch.uint8), pts=0, duration=1, is_key_frame=True
+            )
 
     # The three decode stages, each expressed as a generator that transforms an
     # iterator of inputs into an iterator of outputs. They compose directly (the
@@ -3488,7 +3548,6 @@ def _heic_param(*values):
 
 
 class TestImageDecoder:
-
     # ===== shared helpers =====
 
     def _save_debug(self, decoded, reference, path="debug.png"):


### PR DESCRIPTION
### What

Packets could previously only be obtained from a `Demuxer`.

This adds `Packet.from_bytes` and `Packet.from_tensor` to construct a `Packet` directly from raw compressed data (e.g. from a network stream), with caller-provided `pts`, `duration`, and `is_key_frame`.

`pts` and `duration` are in the consuming decoder's stream time base. `dts` is set to `pts`, so this is only correct for streams without B-frame reordering.