### PR TITLE
Build against FFmpeg 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ with encoder.open_file("output.mp4"):
 ## Installing TorchCodec
 
 1. Install FFmpeg, if it's not already installed. TorchCodec supports all major
-   FFmpeg versions in [4, 8]. Linux distributions usually come with FFmpeg
+   FFmpeg versions in [4, 9]. Linux distributions usually come with FFmpeg
    pre-installed. You'll need FFmpeg that comes with separate shared libraries.
    This is especially relevant for Windows users: these are usually called the
    "shared" releases.

--- a/packaging/repair_wheel.py
+++ b/packaging/repair_wheel.py
@@ -664,7 +664,7 @@ def check_bundling():
                     "ship (libheif is a user-supplied runtime dependency, like "
                     "FFmpeg): " + " ".join(lgpl)
                 )
-            MAX_WHEEL_BYTES = (14 if is_cuda else 6.5) * 1024 * 1024
+            MAX_WHEEL_BYTES = (17 if is_cuda else 10) * 1024 * 1024
             wheel_bytes = wheel.stat().st_size
             if wheel_bytes > MAX_WHEEL_BYTES:
                 raise RuntimeError(

--- a/packaging/repair_wheel.py
+++ b/packaging/repair_wheel.py
@@ -664,7 +664,7 @@ def check_bundling():
                     "ship (libheif is a user-supplied runtime dependency, like "
                     "FFmpeg): " + " ".join(lgpl)
                 )
-            MAX_WHEEL_BYTES = (14 if is_cuda else 6) * 1024 * 1024
+            MAX_WHEEL_BYTES = (14 if is_cuda else 6.5) * 1024 * 1024
             wheel_bytes = wheel.stat().st_size
             if wheel_bytes > MAX_WHEEL_BYTES:
                 raise RuntimeError(

--- a/packaging/repair_wheel.py
+++ b/packaging/repair_wheel.py
@@ -541,7 +541,7 @@ def check_bundling():
 
         Both libtorchcodec_image.so (the image decoders/encoders) and
         libtorchcodec_pybind_ops.so (the Python file-like bridge) are built
-        separately from the FFmpeg-dependent core{4,5,6,7,8}.so libraries and
+        separately from the FFmpeg-dependent core{4,5,6,7,8,9}.so libraries and
         must stay FFmpeg-free:
         - the image lib, to avoid symbol interposition between the bundled image
           codec libs (libjpeg/libpng/libwebp) and the user's FFmpeg, which may

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -711,11 +711,12 @@ if(DEFINED ENV{BUILD_AGAINST_ALL_FFMPEG_FROM_S3})
         you still need a different FFmpeg to be installed for run time!"
     )
 
-    # This will expose the torchcodec::ffmpeg{N} (N=4,5,6,7,8) targets
+    # This will expose the torchcodec::ffmpeg{N} (N=4,5,6,7,8,9) targets
     include(
         ${CMAKE_CURRENT_SOURCE_DIR}/fetch_and_expose_non_gpl_ffmpeg_libs.cmake
     )
 
+    make_torchcodec_libraries(9 torchcodec::ffmpeg9)
     make_torchcodec_libraries(8 torchcodec::ffmpeg8)
     make_torchcodec_libraries(7 torchcodec::ffmpeg7)
     make_torchcodec_libraries(6 torchcodec::ffmpeg6)

--- a/src/torchcodec/_core/fetch_and_expose_non_gpl_ffmpeg_libs.cmake
+++ b/src/torchcodec/_core/fetch_and_expose_non_gpl_ffmpeg_libs.cmake
@@ -41,6 +41,10 @@ if (LINUX)
             f8_sha256
             b9cfd99ae75a14e58300854967d4dc49de0b3daa551df51ea1f52a3f08d2c8af
         )
+        set(
+            f9_sha256
+            e68d3a5a17705740f0f8cf69a92ab65ae47c9e17eb3969b17966bd11ab12b382
+        )
     elseif (LINUX)  # assume x86_64
         set(
             platform_url
@@ -66,6 +70,10 @@ if (LINUX)
         set(
             f8_sha256
             c55b3c1a4b5e4d5fdd7c632bea3ab6f45b4e37cc8e0999dda3f84a8ed8defad8
+        )
+        set(
+            f9_sha256
+            ac033158731d452858f3248f93e51939547e87e3dda4fc0e1dc08ae9087d5a35
         )
   endif()
 elseif (APPLE)
@@ -93,6 +101,10 @@ elseif (APPLE)
         f8_sha256
         beb936b76f25d2621228a12cdb67c9ae3d1eff7aa713ef8d1167ebf0c25bd5ec
     )
+    set(
+        f9_sha256
+        2cd1114e5139aee070959121e0a03cc40d2f0cb771b4a3ecfa28195176e3fa73
+    )
 elseif (WIN32)
     set(
         platform_url
@@ -117,6 +129,10 @@ elseif (WIN32)
     set(
         f8_sha256
         bac845ac79876b104959cb0e7b9dec772a261116344dd17d2f97e7ddfac4a73f
+    )
+    set(
+        f9_sha256
+        228b9f9123ac07e7ca38907e75b0f4b0d97273787c98fad922b0775fe17b86f1
     )
 else()
     message(
@@ -155,8 +171,14 @@ FetchContent_Declare(
     URL_HASH
     SHA256=${f8_sha256}
 )
+FetchContent_Declare(
+    f9
+    URL ${platform_url}/9.0.tar.gz
+    URL_HASH
+    SHA256=${f9_sha256}
+)
 
-FetchContent_MakeAvailable(f4 f5 f6 f7 f8)
+FetchContent_MakeAvailable(f4 f5 f6 f7 f8 f9)
 
 # makes add_ffmpeg_target available
 include("${CMAKE_CURRENT_SOURCE_DIR}/../share/cmake/TorchCodec/ffmpeg_versions.cmake")
@@ -167,3 +189,4 @@ add_ffmpeg_target(5 "${f5_SOURCE_DIR}")
 add_ffmpeg_target(6 "${f6_SOURCE_DIR}")
 add_ffmpeg_target(7 "${f7_SOURCE_DIR}")
 add_ffmpeg_target(8 "${f8_SOURCE_DIR}")
+add_ffmpeg_target(9 "${f9_SOURCE_DIR}")

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -124,7 +124,7 @@ def load_core_libraries() -> tuple[int, str]:
     with PyTorch's runtime so they're accessible through torch.ops.
     """
     exceptions = []
-    for ffmpeg_major_version in (8, 7, 6, 5, 4):
+    for ffmpeg_major_version in (9, 8, 7, 6, 5, 4):
         core_library_name = f"libtorchcodec_core{ffmpeg_major_version}"
         custom_ops_library_name = f"libtorchcodec_custom_ops{ffmpeg_major_version}"
         try:
@@ -145,7 +145,7 @@ def load_core_libraries() -> tuple[int, str]:
     raise RuntimeError(
         f"""Could not load libtorchcodec. Likely causes:
           1. FFmpeg is not properly installed in your environment. We support
-             versions 4, 5, 6, 7, and 8, and we attempt to load libtorchcodec
+             versions 4, 5, 6, 7, 8, and 9, and we attempt to load libtorchcodec
              for each of those versions. Errors for versions not installed on
              your system are expected; only the error for your installed FFmpeg
              version is relevant. On Windows, ensure you've installed the

--- a/src/torchcodec/share/cmake/TorchCodec/ffmpeg_versions.cmake
+++ b/src/torchcodec/share/cmake/TorchCodec/ffmpeg_versions.cmake
@@ -3,7 +3,7 @@
 
 # List of FFmpeg versions that TorchCodec can support - that's not a list of
 # FFmpeg versions available on the current system!
-set(TORCHCODEC_SUPPORTED_FFMPEG_VERSIONS "4;5;6;7;8")
+set(TORCHCODEC_SUPPORTED_FFMPEG_VERSIONS "4;5;6;7;8;9")
 
 # Create and expose torchcodec::ffmpeg${ffmpeg_major_version} target which can
 # then be used as a dependency in other targets.
@@ -32,6 +32,8 @@ function(add_ffmpeg_target ffmpeg_major_version prefix)
             set(library_file_names libavutil.so.59 libavcodec.so.61 libavformat.so.61 libavdevice.so.61 libavfilter.so.10 libswscale.so.8 libswresample.so.5)
         elseif (ffmpeg_major_version EQUAL 8)
             set(library_file_names libavutil.so.60 libavcodec.so.62 libavformat.so.62 libavdevice.so.62 libavfilter.so.11 libswscale.so.9 libswresample.so.6)
+        elseif (ffmpeg_major_version EQUAL 9)
+            set(library_file_names libavutil.so.61 libavcodec.so.63 libavformat.so.63 libavdevice.so.63 libavfilter.so.12 libswscale.so.10 libswresample.so.7)
         endif()
     elseif (APPLE)
         if (ffmpeg_major_version EQUAL 4)
@@ -44,6 +46,8 @@ function(add_ffmpeg_target ffmpeg_major_version prefix)
             set(library_file_names libavutil.59.dylib libavcodec.61.dylib libavformat.61.dylib libavdevice.61.dylib libavfilter.10.dylib libswscale.8.dylib libswresample.5.dylib)
         elseif (ffmpeg_major_version EQUAL 8)
             set(library_file_names libavutil.60.dylib libavcodec.62.dylib libavformat.62.dylib libavdevice.62.dylib libavfilter.11.dylib libswscale.9.dylib libswresample.6.dylib)
+        elseif (ffmpeg_major_version EQUAL 9)
+            set(library_file_names libavutil.61.dylib libavcodec.63.dylib libavformat.63.dylib libavdevice.63.dylib libavfilter.12.dylib libswscale.10.dylib libswresample.7.dylib)
         endif()
     elseif (WIN32)
         set(library_file_names avutil.lib avcodec.lib avformat.lib avdevice.lib avfilter.lib swscale.lib swresample.lib)
@@ -112,6 +116,8 @@ function(add_ffmpeg_target_with_pkg_config ret_ffmpeg_major_version_var)
         set(ffmpeg_major_version "7")
     elseif (${libavcodec_major_version} STREQUAL "62")
         set(ffmpeg_major_version "8")
+    elseif (${libavcodec_major_version} STREQUAL "63")
+        set(ffmpeg_major_version "9")
     else()
         message(FATAL_ERROR "Unsupported libavcodec version: ${libavcodec_major_version}")
     endif()


### PR DESCRIPTION
This should ensure we build against FFmpeg9. We also enabling loading `libtorchcodec_core9.so` if it's found, so this should work for users with FFmpeg 9.

The major caveat is that **we aren't testing against FFmpeg 9** yet. The thing was released literally yesterday and it's not yet available on conda-forge etc. - so we have currently no easy way to validate against it.