### PR TITLE
Let Blocks output the raw YUV frames

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -967,8 +967,6 @@ void BetaCudaDeviceInterface::make_frame_standalone(UniqueAVFrame& av_frame) {
 
 bool BetaCudaDeviceInterface::is_device_frame(
     const UniqueAVFrame& av_frame) const {
-  // Frames NVDEC couldn't handle were decoded on the CPU and their samples are
-  // in host memory; only genuine NVDEC surfaces (NV12/P016) live on the GPU.
   return !is_cpu_fallback(av_frame->format);
 }
 

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -965,6 +965,13 @@ void BetaCudaDeviceInterface::make_frame_standalone(UniqueAVFrame& av_frame) {
       0);
 }
 
+bool BetaCudaDeviceInterface::is_device_frame(
+    const UniqueAVFrame& av_frame) const {
+  // Frames NVDEC couldn't handle were decoded on the CPU and their samples are
+  // in host memory; only genuine NVDEC surfaces (NV12/P016) live on the GPU.
+  return !is_cpu_fallback(av_frame->format);
+}
+
 void BetaCudaDeviceInterface::flush() {
   CudaContextGuard context_guard(device_.index());
   if (decoding_on_cpu_) {

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -80,6 +80,9 @@ cudaVideoSurfaceFormat get_preferred_surface_format(OutputDtype output_dtype) {
 // inferred from its pixel format. This works today because our CPU fallback
 // never yields NV12/P016 frames, but it's only a proxy, and it's not super
 // robust to future changes.
+// Note that we don't rely on decode_on_cpu_ because that field is only relevant
+// when decoding happens, but this interface can be used in
+// color-conversion-only mode.
 bool is_cpu_fallback(int format) {
   return format != AV_PIX_FMT_NV12 && format != AV_PIX_FMT_P016LE;
 }
@@ -348,8 +351,17 @@ void BetaCudaDeviceInterface::initialize_color_conversion(
     const std::vector<std::unique_ptr<Transform>>& transforms,
     const std::optional<FrameDims>& resized_output_dims) {
   output_dtype_ = video_stream_options.output_dtype;
-  if (cpu_fallback_) {
-    cpu_fallback_->initialize_color_conversion(
+
+  if (!decoding_initialized_) {
+    // A ColorConverter (in ColorConverterOnly mode) might need a CPU interface
+    // to color-convert 4:4:4 frames. We create it here unconditionally.
+    cpu_interface_ = create_device_interface(kStableCPU);
+    STD_TORCH_CHECK(
+        cpu_interface_ != nullptr, "Failed to create CPU device interface");
+  }
+
+  if (cpu_interface_) {
+    cpu_interface_->initialize_color_conversion(
         video_stream_options, transforms, resized_output_dims);
   }
   color_conversion_initialized_ = true;
@@ -376,11 +388,12 @@ void BetaCudaDeviceInterface::initialize_video_decoding(
       TC_LOG(
           "Video stream not supported by NVDEC; falling back to CPU decoding.");
     }
-    cpu_fallback_ = create_device_interface(kStableCPU);
+    decoding_on_cpu_ = true;
+    cpu_interface_ = create_device_interface(kStableCPU);
     STD_TORCH_CHECK(
-        cpu_fallback_ != nullptr, "Failed to create CPU device interface");
-    cpu_fallback_->initialize(codec_context_);
-    cpu_fallback_->initialize_video_decoding(
+        cpu_interface_ != nullptr, "Failed to create CPU device interface");
+    cpu_interface_->initialize(codec_context_);
+    cpu_interface_->initialize_video_decoding(
         av_stream, av_format_ctx, video_stream_options);
     return;
   }
@@ -614,8 +627,8 @@ int BetaCudaDeviceInterface::stream_property_change(
 // the NVCUVID parser.
 int BetaCudaDeviceInterface::send_packet(ReferenceAVPacket& packet) {
   CudaContextGuard context_guard(device_.index());
-  if (cpu_fallback_) {
-    return cpu_fallback_->send_packet(packet);
+  if (decoding_on_cpu_) {
+    return cpu_interface_->send_packet(packet);
   }
 
   STD_TORCH_CHECK(
@@ -642,8 +655,8 @@ int BetaCudaDeviceInterface::send_packet(ReferenceAVPacket& packet) {
 
 int BetaCudaDeviceInterface::send_eof_packet() {
   CudaContextGuard context_guard(device_.index());
-  if (cpu_fallback_) {
-    return cpu_fallback_->send_eof_packet();
+  if (decoding_on_cpu_) {
+    return cpu_interface_->send_eof_packet();
   }
 
   CUVIDSOURCEDATAPACKET cuvid_packet = {};
@@ -718,8 +731,8 @@ int BetaCudaDeviceInterface::frame_ready_in_display_order(
 // Moral equivalent of avcodec_receive_frame().
 int BetaCudaDeviceInterface::receive_frame(UniqueAVFrame& av_frame) {
   CudaContextGuard context_guard(device_.index());
-  if (cpu_fallback_) {
-    return cpu_fallback_->receive_frame(av_frame);
+  if (decoding_on_cpu_) {
+    return cpu_interface_->receive_frame(av_frame);
   }
 
   if (ready_frames_.empty()) {
@@ -954,8 +967,8 @@ void BetaCudaDeviceInterface::make_frame_standalone(UniqueAVFrame& av_frame) {
 
 void BetaCudaDeviceInterface::flush() {
   CudaContextGuard context_guard(device_.index());
-  if (cpu_fallback_) {
-    cpu_fallback_->flush();
+  if (decoding_on_cpu_) {
+    cpu_interface_->flush();
     return;
   }
 
@@ -1137,7 +1150,7 @@ void BetaCudaDeviceInterface::convert_av_frame_to_frame_output(
     if (is444) {
       // TODO_API_BREAKDOWN P1: we need to handle this
       FrameOutput cpu_frame_output;
-      cpu_fallback_->convert_av_frame_to_frame_output(
+      cpu_interface_->convert_av_frame_to_frame_output(
           av_frame, cpu_frame_output);
       if (pre_allocated_output_tensor.has_value()) {
         torch::stable::copy_(
@@ -1266,7 +1279,7 @@ OutputDtype BetaCudaDeviceInterface::get_pre_allocation_dtype(
 
 std::string BetaCudaDeviceInterface::get_details() {
   std::string details = "NVDEC CUDA Device Interface.";
-  if (cpu_fallback_) {
+  if (decoding_on_cpu_) {
     details += " Using CPU fallback.";
     if (!nvcuvid_available_) {
       details += " NVCUVID not available!";

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -103,6 +103,8 @@ class BetaCudaDeviceInterface : public DeviceInterface {
 
   void make_frame_standalone(UniqueAVFrame& av_frame) override;
 
+  bool is_device_frame(const UniqueAVFrame& av_frame) const override;
+
   UniqueAVFrame transfer_cpu_frame_to_gpu(
       const AVFrame& cpu_frame,
       AVPixelFormat target_pix_fmt);

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -128,7 +128,9 @@ class BetaCudaDeviceInterface : public DeviceInterface {
   bool decoding_initialized_ = false;
   bool color_conversion_initialized_ = false;
 
-  std::unique_ptr<DeviceInterface> cpu_fallback_;
+  std::unique_ptr<DeviceInterface> cpu_interface_;
+  // Whether this instance decodes on CPU because NVDEC can't handle the stream.
+  bool decoding_on_cpu_ = false;
   bool nvcuvid_available_ = false;
   UniqueSwsContext sws_context_;
 

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -40,7 +40,7 @@ class DeviceInterface {
  public:
   DeviceInterface(const StableDevice& device) : device_(device) {}
 
-  virtual ~DeviceInterface() {};
+  virtual ~DeviceInterface(){};
 
   StableDevice& device() {
     return device_;

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -159,10 +159,6 @@ class DeviceInterface {
   virtual void make_frame_standalone([[maybe_unused]] UniqueAVFrame& av_frame) {
   };
 
-  // Whether av_frame's pixel data lives on this interface's device rather than
-  // in host memory. This is a property of the frame, not of the interface: a
-  // hardware interface that had to fall back to CPU decoding hands out frames
-  // in host memory.
   virtual bool is_device_frame(
       [[maybe_unused]] const UniqueAVFrame& av_frame) const {
     return false;

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -40,7 +40,7 @@ class DeviceInterface {
  public:
   DeviceInterface(const StableDevice& device) : device_(device) {}
 
-  virtual ~DeviceInterface(){};
+  virtual ~DeviceInterface() {};
 
   StableDevice& device() {
     return device_;
@@ -158,6 +158,15 @@ class DeviceInterface {
 
   virtual void make_frame_standalone([[maybe_unused]] UniqueAVFrame& av_frame) {
   };
+
+  // Whether av_frame's pixel data lives on this interface's device rather than
+  // in host memory. This is a property of the frame, not of the interface: a
+  // hardware interface that had to fall back to CPU decoding hands out frames
+  // in host memory.
+  virtual bool is_device_frame(
+      [[maybe_unused]] const UniqueAVFrame& av_frame) const {
+    return false;
+  }
 
   // Flush remaining frames from decoder
   virtual void flush() {

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -72,7 +72,8 @@ PacketDecoder::PacketDecoder(
   device_interface_->initialize(codec_context_);
 
   VideoStreamOptions options;
-  // TODO_API_BREAKDOWN P1: Need to design and figure out behavior of Blocks with HDR data.
+  // TODO_API_BREAKDOWN P1: Need to design and figure out behavior of Blocks
+  // with HDR data.
   options.output_dtype = OutputDtype::UINT8; // dtype not exposed yet
   options.device = device;
 
@@ -102,6 +103,77 @@ int PacketDecoder::receive_frame(UniqueAVFrame& av_frame) {
     device_interface_->make_frame_standalone(av_frame);
   }
   return status;
+}
+
+FramePlanes frame_to_planes(
+    const AVFrame& av_frame,
+    const StableDevice& device,
+    const torch::stable::Tensor& frame_owner) {
+  auto pix_fmt = static_cast<AVPixelFormat>(av_frame.format);
+  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(pix_fmt);
+  STD_TORCH_CHECK(desc != nullptr, "Unknown pixel format on decoded frame");
+  const char* pix_fmt_name = av_get_pix_fmt_name(pix_fmt);
+  std::string fmt_name = pix_fmt_name ? pix_fmt_name : "unknown";
+
+  // Sub-byte-packed, palettised, and float layouts can't be addressed by a
+  // tensor stride; handing them over would require unpacking them into a copy.
+  STD_TORCH_CHECK(
+      !(desc->flags &
+        (AV_PIX_FMT_FLAG_BITSTREAM | AV_PIX_FMT_FLAG_PAL |
+         AV_PIX_FMT_FLAG_FLOAT)),
+      "Cannot expose ",
+      fmt_name,
+      " as a view: sub-byte-packed, palettised, and float pixel formats need a copy.");
+  STD_TORCH_CHECK(
+      desc->nb_components >= 1 && desc->nb_components <= 4,
+      fmt_name,
+      " has an unsupported number of components.");
+
+  FramePlanes result;
+  result.pix_fmt = fmt_name;
+  result.colorspace = static_cast<int64_t>(av_frame.colorspace);
+  result.color_range = static_cast<int64_t>(av_frame.color_range);
+
+  for (int c = 0; c < desc->nb_components; ++c) {
+    const AVComponentDescriptor& comp = desc->comp[c];
+    int64_t bytes_per_sample = (comp.depth > 8) ? 2 : 1;
+    int64_t linesize = av_frame.linesize[comp.plane];
+    STD_TORCH_CHECK(
+        comp.shift == 0 && comp.depth <= 16 && linesize > 0 &&
+            comp.step % bytes_per_sample == 0 &&
+            linesize % bytes_per_sample == 0,
+        "Cannot expose component ",
+        c,
+        " of ",
+        fmt_name,
+        " as a view: its samples aren't a whole number of bytes, or the frame "
+        "is stored bottom-up (negative line size).");
+
+    // Only the chroma components are subsampled; luma and alpha are full size.
+    bool is_chroma = !(desc->flags & AV_PIX_FMT_FLAG_RGB) && (c == 1 || c == 2);
+    int64_t height = is_chroma
+        ? AV_CEIL_RSHIFT(av_frame.height, desc->log2_chroma_h)
+        : av_frame.height;
+    int64_t width = is_chroma
+        ? AV_CEIL_RSHIFT(av_frame.width, desc->log2_chroma_w)
+        : av_frame.width;
+
+    // Copying the owner is just a refcount bump; the frame is freed with the
+    // last view.
+    auto keep_frame_alive = frame_owner;
+    int64_t sizes[] = {height, width};
+    int64_t strides[] = {
+        linesize / bytes_per_sample, comp.step / bytes_per_sample};
+    result.planes.push_back(torch::stable::from_blob(
+        av_frame.data[comp.plane] + comp.offset,
+        {sizes, 2},
+        {strides, 2},
+        device,
+        (comp.depth > 8) ? kStableUInt16 : kStableUInt8,
+        [keep_frame_alive](void*) {}));
+  }
+
+  return result;
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -72,6 +72,13 @@ PacketDecoder::PacketDecoder(
   device_interface_->initialize(codec_context_);
 
   VideoStreamOptions options;
+  // TODO_API_BREAKDOWN P1: HDR/high-bit-depth content. Hardcoding UINT8 makes
+  // NVDEC decode 10-/12-bit content into an 8-bit NV12 surface, silently
+  // dropping the extra precision (only FLOAT32 requests a P016 surface). We
+  // probably don't want to force NV12 for HDR; we should let the caller pick
+  // the output precision (or infer it from the stream) and expose P016 through
+  // the blocks. This needs to stay consistent with what VideoDecoder does for
+  // HDR, so the two paths agree on precision and pixel format.
   options.output_dtype = OutputDtype::UINT8; // dtype not exposed yet
   options.device = device;
 

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -108,7 +108,7 @@ int PacketDecoder::receive_frame(UniqueAVFrame& av_frame) {
 FramePlanes frame_to_planes(
     const AVFrame& av_frame,
     const StableDevice& device,
-    const torch::stable::Tensor& frame_owner) {
+    const torch::stable::Tensor& tensor_handle) {
   auto pix_fmt = static_cast<AVPixelFormat>(av_frame.format);
   const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(pix_fmt);
   STD_TORCH_CHECK(desc != nullptr, "Unknown pixel format on decoded frame");
@@ -158,20 +158,24 @@ FramePlanes frame_to_planes(
         ? AV_CEIL_RSHIFT(av_frame.width, desc->log2_chroma_w)
         : av_frame.width;
 
-    // Copying the owner is just a refcount bump; the frame is freed with the
-    // last view.
-    // TODO_NOW : I don't understand the ownership model here.
-    auto keep_frame_alive = frame_owner;
     int64_t sizes[] = {height, width};
     int64_t strides[] = {
         linesize / bytes_per_sample, comp.step / bytes_per_sample};
+
+    // The planes are views on the AVFrame's data. The AVFrame and its data are
+    // owned by the tensor_handle. We want the planes to outlive the Python
+    // tensor handle (see test_materialize_planes_outlive_frame). So for each
+    // plane, we create a (shallow) copy of the tensor handle, and capture it in
+    // the plane's deleter. As long as a handle [copy] lives, the AVFrame and
+    // its data are alive.
+    torch::stable::Tensor handle_copy = tensor_handle;
     result.planes.push_back(torch::stable::from_blob(
         av_frame.data[comp.plane] + comp.offset,
         {sizes, 2},
         {strides, 2},
         device,
         (comp.depth > 8) ? kStableUInt16 : kStableUInt8,
-        [keep_frame_alive](void*) {}));
+        [handle_copy](void*) {}));
   }
 
   return result;

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -72,13 +72,7 @@ PacketDecoder::PacketDecoder(
   device_interface_->initialize(codec_context_);
 
   VideoStreamOptions options;
-  // TODO_API_BREAKDOWN P1: HDR/high-bit-depth content. Hardcoding UINT8 makes
-  // NVDEC decode 10-/12-bit content into an 8-bit NV12 surface, silently
-  // dropping the extra precision (only FLOAT32 requests a P016 surface). We
-  // probably don't want to force NV12 for HDR; we should let the caller pick
-  // the output precision (or infer it from the stream) and expose P016 through
-  // the blocks. This needs to stay consistent with what VideoDecoder does for
-  // HDR, so the two paths agree on precision and pixel format.
+  // TODO_API_BREAKDOWN P1: Need to design and figure out behavior of Blocks with HDR data.
   options.output_dtype = OutputDtype::UINT8; // dtype not exposed yet
   options.device = device;
 

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -115,8 +115,6 @@ FramePlanes frame_to_planes(
   const char* pix_fmt_name = av_get_pix_fmt_name(pix_fmt);
   std::string fmt_name = pix_fmt_name ? pix_fmt_name : "unknown";
 
-  // Sub-byte-packed, palettised, and float layouts can't be addressed by a
-  // tensor stride; handing them over would require unpacking them into a copy.
   STD_TORCH_CHECK(
       !(desc->flags &
         (AV_PIX_FMT_FLAG_BITSTREAM | AV_PIX_FMT_FLAG_PAL |
@@ -149,6 +147,8 @@ FramePlanes frame_to_planes(
         " as a view: its samples aren't a whole number of bytes, or the frame "
         "is stored bottom-up (negative line size).");
 
+    // Each plan is output as a 2D tensor. Y is full size while U/V (the chroma)
+    // are potentially subsampled by 2.
     // Only the chroma components are subsampled; luma and alpha are full size.
     bool is_chroma = !(desc->flags & AV_PIX_FMT_FLAG_RGB) && (c == 1 || c == 2);
     int64_t height = is_chroma
@@ -160,6 +160,7 @@ FramePlanes frame_to_planes(
 
     // Copying the owner is just a refcount bump; the frame is freed with the
     // last view.
+    // TODO_NOW : I don't understand the ownership model here.
     auto keep_frame_alive = frame_owner;
     int64_t sizes[] = {height, width};
     int64_t strides[] = {

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -127,10 +127,13 @@ FramePlanes frame_to_planes(
       fmt_name,
       " has an unsupported number of components.");
 
+  const char* colorspace_name = av_color_space_name(av_frame.colorspace);
+  const char* color_range_name = av_color_range_name(av_frame.color_range);
+
   FramePlanes result;
   result.pix_fmt = fmt_name;
-  result.colorspace = static_cast<int64_t>(av_frame.colorspace);
-  result.color_range = static_cast<int64_t>(av_frame.color_range);
+  result.colorspace = colorspace_name ? colorspace_name : "unknown";
+  result.color_range = color_range_name ? color_range_name : "unknown";
 
   for (int c = 0; c < desc->nb_components; ++c) {
     const AVComponentDescriptor& comp = desc->comp[c];

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -45,14 +45,10 @@ class FORCE_PUBLIC_VISIBILITY PacketDecoder {
   // if more input is needed, AVERROR_EOF at end, or a negative error code.
   int receive_frame(UniqueAVFrame& av_frame);
 
-  // Whether the frame's pixel data is on this decoder's device or in host
-  // memory. A CUDA decoder yields host frames for streams NVDEC can't handle.
   bool is_device_frame(const UniqueAVFrame& av_frame) const {
     return device_interface_->is_device_frame(av_frame);
   }
 
-  // The device this decoder decodes on. Frames may still be in host memory (see
-  // is_device_frame).
   const StableDevice& device() const {
     return device_interface_->device();
   }
@@ -79,22 +75,6 @@ struct FramePlanes {
   int64_t color_range = 0; // AVColorRange
 };
 
-// Zero-copy views of a decoded frame's own samples, one per component, before
-// any color conversion. Each view is a strided window over the frame's memory
-// as described by the pixel format's per-component plane/offset/step, so
-// semi-planar (nv12, p016) and packed (yuyv422, bgra...) layouts come back as
-// clean separate components without a copy -- the interleaving lives in the
-// sample stride. 10-/12-bit samples come back as uint16 views.
-//
-// `device` is where the frame's samples live (its NVDEC surface for GPU frames,
-// host memory otherwise); the views are built on it, so no data is moved.
-//
-// `frame_owner` is whatever owns `av_frame`'s lifetime; each view captures it
-// so the samples stay valid after the caller drops the frame they came from.
-// Note that we can't instead take a reference on the AVFrame itself: GPU frames
-// aren't refcounted (their data points into a torch tensor attached as
-// opaque_ref), so av_frame_ref() would deep-copy them as if they were host
-// memory.
 FORCE_PUBLIC_VISIBILITY FramePlanes frame_to_planes(
     const AVFrame& av_frame,
     const StableDevice& device,

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -8,7 +8,9 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
+#include <vector>
 
 #include "Demuxer.h"
 #include "DeviceInterface.h"
@@ -65,5 +67,37 @@ class FORCE_PUBLIC_VISIBILITY PacketDecoder {
   SharedAVCodecContext codec_context_;
   AVRational time_base_ = {};
 };
+
+// A decoded frame's own samples, before any color conversion.
+struct FramePlanes {
+  // One view per component, in the frame's native order: (Y, U, V) for YUV,
+  // (R, G, B) for RGB codecs, (Y,) for grayscale, plus a trailing alpha view
+  // when the format has one.
+  std::vector<torch::stable::Tensor> planes;
+  std::string pix_fmt; // FFmpeg pixel-format name, e.g. "yuv420p"
+  int64_t colorspace = 0; // AVColorSpace
+  int64_t color_range = 0; // AVColorRange
+};
+
+// Zero-copy views of a decoded frame's own samples, one per component, before
+// any color conversion. Each view is a strided window over the frame's memory
+// as described by the pixel format's per-component plane/offset/step, so
+// semi-planar (nv12, p016) and packed (yuyv422, bgra...) layouts come back as
+// clean separate components without a copy -- the interleaving lives in the
+// sample stride. 10-/12-bit samples come back as uint16 views.
+//
+// `device` is where the frame's samples live (its NVDEC surface for GPU frames,
+// host memory otherwise); the views are built on it, so no data is moved.
+//
+// `frame_owner` is whatever owns `av_frame`'s lifetime; each view captures it
+// so the samples stay valid after the caller drops the frame they came from.
+// Note that we can't instead take a reference on the AVFrame itself: GPU frames
+// aren't refcounted (their data points into a torch tensor attached as
+// opaque_ref), so av_frame_ref() would deep-copy them as if they were host
+// memory.
+FORCE_PUBLIC_VISIBILITY FramePlanes frame_to_planes(
+    const AVFrame& av_frame,
+    const StableDevice& device,
+    const torch::stable::Tensor& frame_owner);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -70,9 +70,9 @@ struct FramePlanes {
   // (R, G, B) for RGB codecs, (Y,) for grayscale, plus a trailing alpha view
   // when the format has one.
   std::vector<torch::stable::Tensor> planes;
-  std::string pix_fmt; // FFmpeg pixel-format name, e.g. "yuv420p"
-  std::string colorspace; // AVColorSpace name, e.g. "bt709"
-  std::string color_range; // AVColorRange name: "tv" (limited) or "pc" (full)
+  std::string pix_fmt;
+  std::string colorspace;
+  std::string color_range;
 };
 
 FORCE_PUBLIC_VISIBILITY FramePlanes frame_to_planes(

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -71,8 +71,8 @@ struct FramePlanes {
   // when the format has one.
   std::vector<torch::stable::Tensor> planes;
   std::string pix_fmt; // FFmpeg pixel-format name, e.g. "yuv420p"
-  int64_t colorspace = 0; // AVColorSpace
-  int64_t color_range = 0; // AVColorRange
+  std::string colorspace; // AVColorSpace name, e.g. "bt709"
+  std::string color_range; // AVColorRange name: "tv" (limited) or "pc" (full)
 };
 
 FORCE_PUBLIC_VISIBILITY FramePlanes frame_to_planes(

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -43,6 +43,18 @@ class FORCE_PUBLIC_VISIBILITY PacketDecoder {
   // if more input is needed, AVERROR_EOF at end, or a negative error code.
   int receive_frame(UniqueAVFrame& av_frame);
 
+  // Whether the frame's pixel data is on this decoder's device or in host
+  // memory. A CUDA decoder yields host frames for streams NVDEC can't handle.
+  bool is_device_frame(const UniqueAVFrame& av_frame) const {
+    return device_interface_->is_device_frame(av_frame);
+  }
+
+  // The device this decoder decodes on. Frames may still be in host memory (see
+  // is_device_frame).
+  const StableDevice& device() const {
+    return device_interface_->device();
+  }
+
   // The stream time base, used to convert frame pts/duration to seconds.
   AVRational time_base() const {
     return time_base_;

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -78,6 +78,6 @@ struct FramePlanes {
 FORCE_PUBLIC_VISIBILITY FramePlanes frame_to_planes(
     const AVFrame& av_frame,
     const StableDevice& device,
-    const torch::stable::Tensor& frame_owner);
+    const torch::stable::Tensor& tensor_handle);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -37,6 +37,7 @@ FFMPEG_OP_NAMES = frozenset(
         "_blocks_packet_decoder_receive_frame",
         "_blocks_create_color_converter",
         "_blocks_convert_frame",
+        "_blocks_frame_to_planes",
         "_test_frame_pts_equality",
         "_get_container_json_metadata",
         "_get_key_frame_indices",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -112,6 +112,7 @@ _blocks_create_color_converter = (
     torch.ops.torchcodec_ns._blocks_create_color_converter.default
 )
 _blocks_convert_frame = torch.ops.torchcodec_ns._blocks_convert_frame.default
+_blocks_frame_to_planes = torch.ops.torchcodec_ns._blocks_frame_to_planes.default
 
 _test_frame_pts_equality = torch.ops.torchcodec_ns._test_frame_pts_equality.default
 _get_container_json_metadata = (

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -82,9 +82,11 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
       "_blocks_packet_decoder_send_packet(Tensor(a!) decoder, Tensor packet) -> int");
   m.def("_blocks_packet_decoder_send_eof(Tensor(a!) decoder) -> int");
   m.def(
-      "_blocks_packet_decoder_receive_frame(Tensor(a!) decoder) -> (Tensor, int, float, float)");
+      "_blocks_packet_decoder_receive_frame(Tensor(a!) decoder) -> (Tensor, int, float, float, str)");
   m.def("_blocks_create_color_converter(str device=\"cpu\") -> Tensor");
   m.def("_blocks_convert_frame(Tensor(a!) converter, Tensor frame) -> Tensor");
+  m.def(
+      "_blocks_frame_to_planes(Tensor frame, str device) -> (Tensor, Tensor, Tensor, Tensor, str, int, int)");
   m.def("_get_key_frame_indices(Tensor(a!) decoder) -> Tensor");
   m.def("get_json_metadata(Tensor(a!) decoder) -> str");
   m.def("get_container_json_metadata(Tensor(a!) decoder) -> str");
@@ -837,13 +839,25 @@ int64_t _blocks_packet_decoder_send_eof(torch::stable::Tensor& decoder) {
   return static_cast<int64_t>(decoder_ptr->send_eof());
 }
 
-// (frame_handle, status, pts_seconds, duration_seconds). status == 0 means a
-// frame was produced; nonzero (EAGAIN/EOF) means no frame (dummy handle,
-// zeros). pts/duration are stamped here (the decoder knows the stream time
-// base) so the ColorConverter doesn't need to be bound to a stream. Native
-// scalars avoid per-frame .item() overhead.
+std::string device_to_string(const StableDevice& device) {
+  std::string name = device_type_name(device.type());
+  // A negative index means "unspecified" (e.g. device was just "cuda"); leave
+  // it off so the string round-trips and resolves to the current device.
+  if (device.type() != kStableCPU && device.index() >= 0) {
+    name += ":" + std::to_string(device.index());
+  }
+  return name;
+}
+
+// (frame_handle, status, pts_seconds, duration_seconds, device). status == 0
+// means a frame was produced; nonzero (EAGAIN/EOF) means no frame (dummy
+// handle, zeros). pts/duration are stamped here (the decoder knows the stream
+// time base) so the ColorConverter doesn't need to be bound to a stream.
+// `device` is where this frame's samples actually are: not necessarily the
+// decoder's device, since a CUDA decoder yields host frames for streams NVDEC
+// can't handle. Native scalars avoid per-frame .item() overhead.
 using OpsReceiveFrameOutput =
-    std::tuple<torch::stable::Tensor, int64_t, double, double>;
+    std::tuple<torch::stable::Tensor, int64_t, double, double, std::string>;
 
 OpsReceiveFrameOutput _blocks_packet_decoder_receive_frame(
     torch::stable::Tensor& decoder) {
@@ -856,16 +870,21 @@ OpsReceiveFrameOutput _blocks_packet_decoder_receive_frame(
         torch::stable::full({1}, 0, kStableInt64),
         static_cast<int64_t>(status),
         0.0,
-        0.0);
+        0.0,
+        std::string("cpu"));
   }
   AVRational time_base = decoder_ptr->time_base();
   double pts_seconds = pts_to_seconds(get_pts_or_dts(*av_frame), time_base);
   double duration_seconds = pts_to_seconds(get_duration(*av_frame), time_base);
+  std::string device = decoder_ptr->is_device_frame(av_frame)
+      ? device_to_string(decoder_ptr->device())
+      : std::string("cpu");
   return std::make_tuple(
       wrap_pointer_to_tensor(std::move(av_frame)),
       static_cast<int64_t>(0),
       pts_seconds,
-      duration_seconds);
+      duration_seconds,
+      device);
 }
 
 torch::stable::Tensor _blocks_create_color_converter(std::string device) {
@@ -880,6 +899,104 @@ torch::stable::Tensor _blocks_convert_frame(
   ColorConverter* converter_ptr =
       unwrap_tensor_to_pointer<ColorConverter>(converter);
   return converter_ptr->convert(*unwrap_tensor_to_pointer<AVFrame>(frame));
+}
+
+// Zero-copy views of a decoded frame's own samples, one per component (Y/U/V,
+// R/G/B, with optional trailing alpha), before any color conversion. Each view
+// is a strided window over the frame's memory as described by the pixel
+// format's per-component plane/offset/step, so semi-planar (nv12, p016) and
+// packed (yuyv422, bgra...) layouts come back as clean separate components
+// without a copy -- the interleaving lives in the sample stride. 10-/12-bit
+// samples come back as uint16 views. Absent component slots come back as empty
+// tensors; the pixel-format name says how to interpret the real ones.
+//
+// `device` is where the frame's samples live (its NVDEC surface for GPU frames,
+// host memory otherwise); the views are built on it, so no data is moved.
+using OpsFrameToPlanesOutput = std::tuple<
+    torch::stable::Tensor,
+    torch::stable::Tensor,
+    torch::stable::Tensor,
+    torch::stable::Tensor,
+    std::string, // pixel-format name, e.g. "yuv420p"
+    int64_t, // AVColorSpace
+    int64_t>; // AVColorRange
+
+OpsFrameToPlanesOutput _blocks_frame_to_planes(
+    torch::stable::Tensor& frame,
+    std::string device) {
+  AVFrame* av_frame = unwrap_tensor_to_pointer<AVFrame>(frame);
+  StableDevice tensor_device(device);
+  auto pix_fmt = static_cast<AVPixelFormat>(av_frame->format);
+  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(pix_fmt);
+  STD_TORCH_CHECK(desc != nullptr, "Unknown pixel format on decoded frame");
+  const char* pix_fmt_name = av_get_pix_fmt_name(pix_fmt);
+  std::string fmt_name = pix_fmt_name ? pix_fmt_name : "unknown";
+
+  // Sub-byte-packed, palettised, and float layouts can't be addressed by a
+  // tensor stride; handing them over would require unpacking them into a copy.
+  STD_TORCH_CHECK(
+      !(desc->flags &
+        (AV_PIX_FMT_FLAG_BITSTREAM | AV_PIX_FMT_FLAG_PAL |
+         AV_PIX_FMT_FLAG_FLOAT)),
+      "Cannot expose ",
+      fmt_name,
+      " as a view: sub-byte-packed, palettised, and float pixel formats need a copy.");
+  STD_TORCH_CHECK(
+      desc->nb_components >= 1 && desc->nb_components <= 4,
+      fmt_name,
+      " has an unsupported number of components.");
+
+  std::vector<torch::stable::Tensor> views;
+  for (int c = 0; c < desc->nb_components; ++c) {
+    const AVComponentDescriptor& comp = desc->comp[c];
+    int64_t bytes_per_sample = (comp.depth > 8) ? 2 : 1;
+    int64_t linesize = av_frame->linesize[comp.plane];
+    STD_TORCH_CHECK(
+        comp.shift == 0 && comp.depth <= 16 && linesize > 0 &&
+            comp.step % bytes_per_sample == 0 &&
+            linesize % bytes_per_sample == 0,
+        "Cannot expose component ",
+        c,
+        " of ",
+        fmt_name,
+        " as a view: its samples aren't a whole number of bytes, or the frame "
+        "is stored bottom-up (negative line size).");
+
+    // Only the chroma components are subsampled; luma and alpha are full size.
+    bool is_chroma = !(desc->flags & AV_PIX_FMT_FLAG_RGB) && (c == 1 || c == 2);
+    int64_t height = is_chroma
+        ? AV_CEIL_RSHIFT(av_frame->height, desc->log2_chroma_h)
+        : av_frame->height;
+    int64_t width = is_chroma
+        ? AV_CEIL_RSHIFT(av_frame->width, desc->log2_chroma_w)
+        : av_frame->width;
+
+    // The view keeps a refcount on the frame handle tensor, so the samples stay
+    // valid even after the caller drops the DecodedFrame they came from.
+    // Copying the handle is just a refcount bump; the AVFrame is freed with the
+    // last view.
+    auto keep_frame_alive = frame;
+    int64_t sizes[] = {height, width};
+    int64_t strides[] = {
+        linesize / bytes_per_sample, comp.step / bytes_per_sample};
+    views.push_back(torch::stable::from_blob(
+        av_frame->data[comp.plane] + comp.offset,
+        {sizes, 2},
+        {strides, 2},
+        tensor_device,
+        (comp.depth > 8) ? kStableUInt16 : kStableUInt8,
+        [keep_frame_alive](void*) {}));
+  }
+
+  views.resize(4, torch::stable::empty({int64_t(0)}, kStableUInt8));
+  return std::make_tuple(
+      views[0],
+      views[1],
+      views[2],
+      views[3],
+      fmt_name,
+      static_cast<int64_t>(av_frame->colorspace),
+      static_cast<int64_t>(av_frame->color_range));
 }
 
 // For testing only. We need to implement this operation as a core library
@@ -1445,6 +1562,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
       "_blocks_packet_decoder_receive_frame",
       TORCH_BOX(&_blocks_packet_decoder_receive_frame));
   m.impl("_blocks_convert_frame", TORCH_BOX(&_blocks_convert_frame));
+  m.impl("_blocks_frame_to_planes", TORCH_BOX(&_blocks_frame_to_planes));
   m.impl("_test_frame_pts_equality", TORCH_BOX(&_test_frame_pts_equality));
   m.impl(
       "scan_all_streams_to_update_metadata",

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -839,6 +839,7 @@ int64_t _blocks_packet_decoder_send_eof(torch::stable::Tensor& decoder) {
   return static_cast<int64_t>(decoder_ptr->send_eof());
 }
 
+// TODO_API_BREAKDOWN P1: I hate this.
 std::string device_to_string(const StableDevice& device) {
   std::string name = device_type_name(device.type());
   // A negative index means "unspecified" (e.g. device was just "cuda"); leave
@@ -853,9 +854,7 @@ std::string device_to_string(const StableDevice& device) {
 // means a frame was produced; nonzero (EAGAIN/EOF) means no frame (dummy
 // handle, zeros). pts/duration are stamped here (the decoder knows the stream
 // time base) so the ColorConverter doesn't need to be bound to a stream.
-// `device` is where this frame's samples actually are: not necessarily the
-// decoder's device, since a CUDA decoder yields host frames for streams NVDEC
-// can't handle. Native scalars avoid per-frame .item() overhead.
+// Native scalars avoid per-frame .item() overhead.
 using OpsReceiveFrameOutput =
     std::tuple<torch::stable::Tensor, int64_t, double, double, std::string>;
 
@@ -922,6 +921,8 @@ OpsFrameToPlanesOutput _blocks_frame_to_planes(
   FramePlanes result =
       frame_to_planes(*av_frame, StableDevice(device), /*frame_owner=*/frame);
 
+  // Op schema wants a fixed number of planes, so we pad with empty tensors that
+  // then get removed at the Python level.
   std::vector<torch::stable::Tensor> views = std::move(result.planes);
   views.resize(4, torch::stable::empty({int64_t(0)}, kStableUInt8));
   return std::make_tuple(

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -901,17 +901,9 @@ torch::stable::Tensor _blocks_convert_frame(
   return converter_ptr->convert(*unwrap_tensor_to_pointer<AVFrame>(frame));
 }
 
-// Zero-copy views of a decoded frame's own samples, one per component (Y/U/V,
-// R/G/B, with optional trailing alpha), before any color conversion. Each view
-// is a strided window over the frame's memory as described by the pixel
-// format's per-component plane/offset/step, so semi-planar (nv12, p016) and
-// packed (yuyv422, bgra...) layouts come back as clean separate components
-// without a copy -- the interleaving lives in the sample stride. 10-/12-bit
-// samples come back as uint16 views. Absent component slots come back as empty
-// tensors; the pixel-format name says how to interpret the real ones.
-//
-// `device` is where the frame's samples live (its NVDEC surface for GPU frames,
-// host memory otherwise); the views are built on it, so no data is moved.
+// See frame_to_planes() for what these views are. The op schema is fixed-width,
+// so components the format doesn't have come back as empty tensors; the
+// pixel-format name says how to interpret the real ones.
 using OpsFrameToPlanesOutput = std::tuple<
     torch::stable::Tensor,
     torch::stable::Tensor,
@@ -925,78 +917,21 @@ OpsFrameToPlanesOutput _blocks_frame_to_planes(
     torch::stable::Tensor& frame,
     std::string device) {
   AVFrame* av_frame = unwrap_tensor_to_pointer<AVFrame>(frame);
-  StableDevice tensor_device(device);
-  auto pix_fmt = static_cast<AVPixelFormat>(av_frame->format);
-  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(pix_fmt);
-  STD_TORCH_CHECK(desc != nullptr, "Unknown pixel format on decoded frame");
-  const char* pix_fmt_name = av_get_pix_fmt_name(pix_fmt);
-  std::string fmt_name = pix_fmt_name ? pix_fmt_name : "unknown";
+  // The frame handle tensor is what owns the AVFrame, so it's what the views
+  // must keep alive.
+  FramePlanes result =
+      frame_to_planes(*av_frame, StableDevice(device), /*frame_owner=*/frame);
 
-  // Sub-byte-packed, palettised, and float layouts can't be addressed by a
-  // tensor stride; handing them over would require unpacking them into a copy.
-  STD_TORCH_CHECK(
-      !(desc->flags &
-        (AV_PIX_FMT_FLAG_BITSTREAM | AV_PIX_FMT_FLAG_PAL |
-         AV_PIX_FMT_FLAG_FLOAT)),
-      "Cannot expose ",
-      fmt_name,
-      " as a view: sub-byte-packed, palettised, and float pixel formats need a copy.");
-  STD_TORCH_CHECK(
-      desc->nb_components >= 1 && desc->nb_components <= 4,
-      fmt_name,
-      " has an unsupported number of components.");
-
-  std::vector<torch::stable::Tensor> views;
-  for (int c = 0; c < desc->nb_components; ++c) {
-    const AVComponentDescriptor& comp = desc->comp[c];
-    int64_t bytes_per_sample = (comp.depth > 8) ? 2 : 1;
-    int64_t linesize = av_frame->linesize[comp.plane];
-    STD_TORCH_CHECK(
-        comp.shift == 0 && comp.depth <= 16 && linesize > 0 &&
-            comp.step % bytes_per_sample == 0 &&
-            linesize % bytes_per_sample == 0,
-        "Cannot expose component ",
-        c,
-        " of ",
-        fmt_name,
-        " as a view: its samples aren't a whole number of bytes, or the frame "
-        "is stored bottom-up (negative line size).");
-
-    // Only the chroma components are subsampled; luma and alpha are full size.
-    bool is_chroma = !(desc->flags & AV_PIX_FMT_FLAG_RGB) && (c == 1 || c == 2);
-    int64_t height = is_chroma
-        ? AV_CEIL_RSHIFT(av_frame->height, desc->log2_chroma_h)
-        : av_frame->height;
-    int64_t width = is_chroma
-        ? AV_CEIL_RSHIFT(av_frame->width, desc->log2_chroma_w)
-        : av_frame->width;
-
-    // The view keeps a refcount on the frame handle tensor, so the samples stay
-    // valid even after the caller drops the DecodedFrame they came from.
-    // Copying the handle is just a refcount bump; the AVFrame is freed with the
-    // last view.
-    auto keep_frame_alive = frame;
-    int64_t sizes[] = {height, width};
-    int64_t strides[] = {
-        linesize / bytes_per_sample, comp.step / bytes_per_sample};
-    views.push_back(torch::stable::from_blob(
-        av_frame->data[comp.plane] + comp.offset,
-        {sizes, 2},
-        {strides, 2},
-        tensor_device,
-        (comp.depth > 8) ? kStableUInt16 : kStableUInt8,
-        [keep_frame_alive](void*) {}));
-  }
-
+  std::vector<torch::stable::Tensor> views = std::move(result.planes);
   views.resize(4, torch::stable::empty({int64_t(0)}, kStableUInt8));
   return std::make_tuple(
       views[0],
       views[1],
       views[2],
       views[3],
-      fmt_name,
-      static_cast<int64_t>(av_frame->colorspace),
-      static_cast<int64_t>(av_frame->color_range));
+      result.pix_fmt,
+      result.colorspace,
+      result.color_range);
 }
 
 // For testing only. We need to implement this operation as a core library

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -86,7 +86,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def("_blocks_create_color_converter(str device=\"cpu\") -> Tensor");
   m.def("_blocks_convert_frame(Tensor(a!) converter, Tensor frame) -> Tensor");
   m.def(
-      "_blocks_frame_to_planes(Tensor frame, str device) -> (Tensor, Tensor, Tensor, Tensor, str, int, int)");
+      "_blocks_frame_to_planes(Tensor frame, str device) -> (Tensor, Tensor, Tensor, Tensor, str, str, str)");
   m.def("_get_key_frame_indices(Tensor(a!) decoder) -> Tensor");
   m.def("get_json_metadata(Tensor(a!) decoder) -> str");
   m.def("get_container_json_metadata(Tensor(a!) decoder) -> str");
@@ -908,9 +908,9 @@ using OpsFrameToPlanesOutput = std::tuple<
     torch::stable::Tensor,
     torch::stable::Tensor,
     torch::stable::Tensor,
-    std::string, // pixel-format name, e.g. "yuv420p"
-    int64_t, // AVColorSpace
-    int64_t>; // AVColorRange
+    std::string, // pixel-format
+    std::string, // colorspace
+    std::string>; // color range
 
 OpsFrameToPlanesOutput _blocks_frame_to_planes(
     torch::stable::Tensor& tensor_handle,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -913,13 +913,11 @@ using OpsFrameToPlanesOutput = std::tuple<
     int64_t>; // AVColorRange
 
 OpsFrameToPlanesOutput _blocks_frame_to_planes(
-    torch::stable::Tensor& frame,
+    torch::stable::Tensor& tensor_handle,
     std::string device) {
-  AVFrame* av_frame = unwrap_tensor_to_pointer<AVFrame>(frame);
-  // The frame handle tensor is what owns the AVFrame, so it's what the views
-  // must keep alive.
+  AVFrame* av_frame = unwrap_tensor_to_pointer<AVFrame>(tensor_handle);
   FramePlanes result =
-      frame_to_planes(*av_frame, StableDevice(device), /*frame_owner=*/frame);
+      frame_to_planes(*av_frame, StableDevice(device), tensor_handle);
 
   // Op schema wants a fixed number of planes, so we pad with empty tensors that
   // then get removed at the Python level.

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -850,11 +850,7 @@ std::string device_to_string(const StableDevice& device) {
   return name;
 }
 
-// (frame_handle, status, pts_seconds, duration_seconds, device). status == 0
-// means a frame was produced; nonzero (EAGAIN/EOF) means no frame (dummy
-// handle, zeros). pts/duration are stamped here (the decoder knows the stream
-// time base) so the ColorConverter doesn't need to be bound to a stream.
-// Native scalars avoid per-frame .item() overhead.
+// (frame_handle, status, pts_seconds, duration_seconds, device).
 using OpsReceiveFrameOutput =
     std::tuple<torch::stable::Tensor, int64_t, double, double, std::string>;
 
@@ -900,9 +896,6 @@ torch::stable::Tensor _blocks_convert_frame(
   return converter_ptr->convert(*unwrap_tensor_to_pointer<AVFrame>(frame));
 }
 
-// See frame_to_planes() for what these views are. The op schema is fixed-width,
-// so components the format doesn't have come back as empty tensors; the
-// pixel-format name says how to interpret the real ones.
 using OpsFrameToPlanesOutput = std::tuple<
     torch::stable::Tensor,
     torch::stable::Tensor,

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -59,6 +59,8 @@ class DecodedFrame:
     # TODO_API_BREAKDOWN P1: Really need to think hard about the API of *all* of
     # this.
     # materialize()?
+    # What about the planes - should they be 2D (right now they are)? Should we
+    # give them names?
     def materialize(self) -> tuple[tuple[torch.Tensor, ...], str, int, int]:
         p0, p1, p2, p3, pix_fmt, colorspace, color_range = _blocks_frame_to_planes(
             self._handle, self._device

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -23,6 +23,8 @@ class Packet:
         self._handle = handle
 
 
+# TODO_API_BREAKDOWN P1: API design - especially the materialize() method but
+# also the public fields, class name etc.
 class DecodedFrame:
     """A decoded (YUV) frame: an opaque, thread-movable handle to the raw frame
     plus its presentation timestamp and duration (in seconds).
@@ -49,37 +51,19 @@ class DecodedFrame:
         self.pts_seconds = pts_seconds
         self.duration_seconds = duration_seconds
 
+    # TODO_API_BREAKDOWN P2 Why is this a property???
     @property
     def device(self) -> str:
         return self._device
 
+    # TODO_API_BREAKDOWN P1: Really need to think hard about the API of *all* of
+    # this.
+    # materialize()?
     def materialize(self) -> tuple[tuple[torch.Tensor, ...], str, int, int]:
-        """Expose this frame's own samples as zero-copy views, before any color
-        conversion.
-
-        Returns ``(planes, pix_fmt, colorspace, color_range)``. ``planes`` holds
-        one strided view per component, in the frame's native order: ``(Y, U, V)``
-        for the common YUV formats (yuv420p, yuv444p, nv12, p016...), ``(R, G, B)``
-        for RGB codecs, ``(Y,)`` for grayscale, plus a trailing alpha view when
-        the format has one. Semi-planar (nv12, p016) and packed layouts come back
-        as clean separate components -- the interleaving is hidden in the view's
-        sample stride -- so 4:2:0 chroma views are half-resolution and are often
-        non-contiguous. ``.contiguous()`` is the only thing that ever copies.
-
-        Nothing is copied, so the samples are exactly what the codec produced,
-        and 10-/12-bit (HDR) content keeps its full precision as uint16 views.
-        The views live on :attr:`device` (a CUDA frame's samples stay on the
-        GPU) and keep the frame alive, so they stay valid after this
-        :class:`DecodedFrame` is dropped.
-
-        ``pix_fmt`` is the FFmpeg pixel-format name (e.g. ``"yuv420p"``, or
-        ``"nv12"`` / ``"p010le"`` for NVDEC-decoded frames). ``colorspace`` and
-        ``color_range`` are the frame's ``AVColorSpace`` / ``AVColorRange`` enum
-        values, for callers doing their own color math.
-        """
         p0, p1, p2, p3, pix_fmt, colorspace, color_range = _blocks_frame_to_planes(
             self._handle, self._device
         )
         # Absent components come back as empty tensors; real ones are 2D views.
         planes = tuple(p for p in (p0, p1, p2, p3) if p.numel() > 0)
+        # TODO_API_BREAKDOWN P1: yeah this should be a dataclass or something.
         return planes, pix_fmt, colorspace, color_range

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -61,7 +61,7 @@ class DecodedFrame:
     # materialize()?
     # What about the planes - should they be 2D (right now they are)? Should we
     # give them names?
-    def materialize(self) -> tuple[tuple[torch.Tensor, ...], str, int, int]:
+    def materialize(self) -> tuple[tuple[torch.Tensor, ...], str, str, str]:
         p0, p1, p2, p3, pix_fmt, colorspace, color_range = _blocks_frame_to_planes(
             self._handle, self._device
         )

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -52,6 +52,7 @@ class DecodedFrame:
         self.duration_seconds = duration_seconds
 
     # TODO_API_BREAKDOWN P2 Why is this a property???
+    # Do we even need to havet this?
     @property
     def device(self) -> str:
         return self._device

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import torch
 
+from torchcodec._core.ops import _blocks_frame_to_planes
+
 
 class Packet:
     """Opaque, thread-movable handle to a demuxed (compressed) packet.
@@ -29,6 +31,10 @@ class DecodedFrame:
     handle wraps a raw pointer and is process-local. pts/duration are stamped by
     the decoder (which knows the stream time base) and carried here so the
     :class:`ColorConverter` need not be bound to any stream.
+
+    ``device`` is where this frame's samples actually are, which is not
+    necessarily the device its decoder was created with: a CUDA decoder falls
+    back to CPU decoding for streams NVDEC can't handle.
     """
 
     def __init__(
@@ -36,7 +42,44 @@ class DecodedFrame:
         handle: torch.Tensor,
         pts_seconds: float,
         duration_seconds: float,
+        device: str = "cpu",
     ):
         self._handle = handle
+        self._device = device
         self.pts_seconds = pts_seconds
         self.duration_seconds = duration_seconds
+
+    @property
+    def device(self) -> str:
+        return self._device
+
+    def materialize(self) -> tuple[tuple[torch.Tensor, ...], str, int, int]:
+        """Expose this frame's own samples as zero-copy views, before any color
+        conversion.
+
+        Returns ``(planes, pix_fmt, colorspace, color_range)``. ``planes`` holds
+        one strided view per component, in the frame's native order: ``(Y, U, V)``
+        for the common YUV formats (yuv420p, yuv444p, nv12, p016...), ``(R, G, B)``
+        for RGB codecs, ``(Y,)`` for grayscale, plus a trailing alpha view when
+        the format has one. Semi-planar (nv12, p016) and packed layouts come back
+        as clean separate components -- the interleaving is hidden in the view's
+        sample stride -- so 4:2:0 chroma views are half-resolution and are often
+        non-contiguous. ``.contiguous()`` is the only thing that ever copies.
+
+        Nothing is copied, so the samples are exactly what the codec produced,
+        and 10-/12-bit (HDR) content keeps its full precision as uint16 views.
+        The views live on :attr:`device` (a CUDA frame's samples stay on the
+        GPU) and keep the frame alive, so they stay valid after this
+        :class:`DecodedFrame` is dropped.
+
+        ``pix_fmt`` is the FFmpeg pixel-format name (e.g. ``"yuv420p"``, or
+        ``"nv12"`` / ``"p010le"`` for NVDEC-decoded frames). ``colorspace`` and
+        ``color_range`` are the frame's ``AVColorSpace`` / ``AVColorRange`` enum
+        values, for callers doing their own color math.
+        """
+        p0, p1, p2, p3, pix_fmt, colorspace, color_range = _blocks_frame_to_planes(
+            self._handle, self._device
+        )
+        # Absent components come back as empty tensors; real ones are 2D views.
+        planes = tuple(p for p in (p0, p1, p2, p3) if p.numel() > 0)
+        return planes, pix_fmt, colorspace, color_range

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -40,12 +40,17 @@ class PacketDecoder:
     def _drain(self) -> list[DecodedFrame]:
         frames = []
         while True:
-            handle, status, pts_seconds, duration_seconds = (
+            handle, status, pts_seconds, duration_seconds, device = (
                 _blocks_packet_decoder_receive_frame(self._handle)
             )
             if status != 0:  # EAGAIN (need more packets) or EOF: nothing ready
                 break
-            frames.append(DecodedFrame(handle, pts_seconds, duration_seconds))
+            frames.append(
+                # `device` is per-frame, not the decoder's: NVDEC falls back to
+                # CPU decoding for streams it can't handle, and those frames'
+                # samples are in host memory.
+                DecodedFrame(handle, pts_seconds, duration_seconds, device=device)
+            )
         return frames
 
     def decode(self, packet: Packet) -> list[DecodedFrame]:

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -46,9 +46,6 @@ class PacketDecoder:
             if status != 0:  # EAGAIN (need more packets) or EOF: nothing ready
                 break
             frames.append(
-                # `device` is per-frame, not the decoder's: NVDEC falls back to
-                # CPU decoding for streams it can't handle, and those frames'
-                # samples are in host memory.
                 DecodedFrame(handle, pts_seconds, duration_seconds, device=device)
             )
         return frames

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3629,14 +3629,14 @@ class TestBlocks:
 
     @pytest.mark.parametrize("device", _block_devices())
     def test_materialize_is_a_view(self, device):
-        # Two independent materialize() calls view the SAME underlying buffer,
+        # Two independent materialize() calls view the same underlying buffer,
         # so a write through one is visible through the other.
         frame, _ = self._first_frame(NASA_VIDEO.path, device)
         planes_a, *_ = frame.materialize()
         planes_b, *_ = frame.materialize()
 
         original = int(planes_a[0][0, 0].item())
-        planes_a[0][0, 0] = original ^ 0xFF
+        planes_a[0][0, 0] = original ^ 0xFF  # flip first pixel in Y
         assert int(planes_b[0][0, 0].item()) == (original ^ 0xFF)
 
     @pytest.mark.parametrize("video", _MATERIALIZE_VIDEOS)
@@ -3659,17 +3659,16 @@ class TestBlocks:
     @pytest.mark.parametrize("device", _block_devices())
     def test_materialize_neutral_chroma_is_grayscale(self, video, device):
         # Forcing the chroma planes to neutral (128) yields a gray image
-        # (R == G == B). This pins down which planes are the chroma components
-        # and that the writes land in the buffer the converter reads.
+        # (R == G == B). Not testing much, but fun - isn't it?
         frame, converter = self._first_frame(video.path, device)
         planes, pix_fmt, *_ = frame.materialize()
-        assert planes[0].dtype == torch.uint8  # both assets are 8-bit
+        assert planes[0].dtype == torch.uint8
 
-        for chroma in planes[1:]:
-            chroma.fill_(128)
+        _, U, V = planes
+        U.fill_(128)
+        V.fill_(128)
 
         r, g, b = converter.convert(frame).data.to(torch.int16)
-        # atol=1 for integer rounding in the CUDA color-conversion kernel.
         torch.testing.assert_close(r, g, atol=1, rtol=0)
         torch.testing.assert_close(g, b, atol=1, rtol=0)
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3405,8 +3405,6 @@ class TestBlocks:
             ),
         )
 
-    # TODO_API_BREAKDOWN P0: We need to test all assets. Generally we need more
-    # tests for all features / edge cases that were eventually fixed.
     @pytest.mark.parametrize(
         "video",
         (
@@ -3447,9 +3445,12 @@ class TestBlocks:
     )
     @pytest.mark.parametrize("device", _block_devices())
     def test_matches_video_decoder(self, video, decode_method, device):
-        # TODO_API_BREAKDOWN P0: this fails on CUDA and must be fixed. The blocks
+        # TODO_API_BREAKDOWN P1: this fails on CUDA and must be fixed. The blocks
         # Demuxer doesn't honor AV_PKT_FLAG_DISCARD (unlike SingleStreamDecoder),
         # so it emits the extra frames trimmed away by the mp4 edit list.
+        # This is kinda related to exact and approximate mode (not exposed on
+        # Blocks (yet??)) so we might want to address that once we have
+        # addressed seeking in the blocks - if we ever support that.
         if device == "cuda" and video is DISCARD_FIRST_KEYFRAME_VIDEO:
             pytest.skip("Blocks pipeline does not handle this asset on CUDA yet.")
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -7,7 +7,6 @@
 import concurrent.futures
 import contextlib
 import gc
-import math
 import queue
 import threading
 from functools import partial
@@ -3315,16 +3314,6 @@ _MATERIALIZE_VIDEOS = (
 )
 
 
-def _chroma_log2(pix_fmt):
-    # (log2 horizontal, log2 vertical) chroma subsampling of a YUV pixel format.
-    if "444" in pix_fmt:
-        return (0, 0)
-    if "422" in pix_fmt or "nv16" in pix_fmt:
-        return (1, 0)
-    # 4:2:0 planar (yuv420p...) and semi-planar (nv12, p010, p016).
-    return (1, 1)
-
-
 def _is_high_depth(pix_fmt):
     # Whether samples need uint16. nv12/nv21 contain "12"/"21" but are 8-bit.
     if pix_fmt in ("nv12", "nv21", "nv16", "nv24"):
@@ -3586,40 +3575,40 @@ class TestBlocks:
         planes, pix_fmt, colorspace, color_range = frame.materialize()
 
         assert isinstance(pix_fmt, str) and pix_fmt
+        # TODO_NOW Really? int??
         assert isinstance(colorspace, int)
         assert isinstance(color_range, int)
 
         # All planes are 2D views living on the frame's own device.
+        # TODO_API_BREAKDOWN P1: Can there be more planes? Should test?
+        assert len(planes) == 3
         for plane in planes:
-            # TODO_API_BREAKDOWN P0 Why 2??
             assert plane.ndim == 2
             assert plane.device.type == frame.device
 
-        # TODO_API_BREAKDOWN P0 getting uint16 isn't expected - we never go
+        # TODO_NOW getting uint16 isn't expected - we never go
         # through P016 on CUDA, for example. There's a TODO about handling HDr
         # in general, should figure that out then.
         expected_dtype = torch.uint16 if _is_high_depth(pix_fmt) else torch.uint8
         assert all(plane.dtype == expected_dtype for plane in planes)
 
-        # The luma plane matches the color-converted frame's spatial size...
+        Y, U, V = planes
         height, width = converter.convert(frame).data.shape[1:]
-        assert tuple(planes[0].shape) == (height, width)
+        assert Y.shape == (height, width)
 
-        # ...and the two chroma planes are subsampled per the pixel format,
-        # rounding up for odd dimensions (as AV_CEIL_RSHIFT does in C++).
-        assert len(planes) == 3  # every asset here is YUV without alpha
-        log2w, log2h = _chroma_log2(pix_fmt)
-        expected_chroma = (
-            math.ceil(height / (1 << log2h)),
-            math.ceil(width / (1 << log2w)),
+        # Below is just a fancy way to divide by 2 accounting for odd sizes,
+        # matching the FFmpeg logic
+        log2_h, log2_w = (0, 0) if "444" in pix_fmt else (1, 1)
+        expected_chroma_shape = (
+            (height + (1 << log2_h) - 1) >> log2_h,
+            (width + (1 << log2_w) - 1) >> log2_w,
         )
-        for chroma in planes[1:]:
-            assert tuple(chroma.shape) == expected_chroma
+        assert U.shape == V.shape == expected_chroma_shape
 
     @pytest.mark.parametrize("device", _block_devices())
     def test_materialize_mutation_visible_in_color_convert(self, device):
         # materialize() returns views into the frame's own memory, so editing
-        # them and color-converting the SAME frame reflects the edit.
+        # them and color-converting the frame reflects the edit.
         frame, converter = self._first_frame(NASA_VIDEO.path, device)
 
         original = converter.convert(frame).data.clone()
@@ -3629,15 +3618,17 @@ class TestBlocks:
             plane.fill_(value)  # overwrite Y, U, V with distinct constants
         edited = converter.convert(frame).data
 
-        # The edit changed the output...
         assert not torch.equal(edited, original)
-        # ...and since every plane is now spatially constant, each RGB channel
-        # is a single color across all pixels.
+        max_abs_diff = (edited.to(torch.int32) - original.to(torch.int32)).abs().max()
+        assert max_abs_diff.item() > 50
+
+        # since every plane is now a constant value, each RGB channel is a
+        # single color across all pixels.
         for channel in edited:
             assert channel.min().item() == channel.max().item()
 
     @pytest.mark.parametrize("device", _block_devices())
-    def test_materialize_is_a_view_not_a_copy(self, device):
+    def test_materialize_is_a_view(self, device):
         # Two independent materialize() calls view the SAME underlying buffer,
         # so a write through one is visible through the other.
         frame, _ = self._first_frame(NASA_VIDEO.path, device)
@@ -3685,7 +3676,7 @@ class TestBlocks:
     @pytest.mark.needs_cuda
     @pytest.mark.parametrize("video", (H265_VIDEO, TESTSRC2_ODD_HEIGHT_AND_WIDTH_444))
     def test_materialize_cpu_fallback_stays_on_cpu(self, video):
-        # TODO_API_BREAKDOWN P0: This may not be what we want. We probalby want
+        # TODO_NOW: This may not be what we want. We probalby want
         # to output CUDA data.  But how? Do we put the YUV420 on CUDA? Then we
         # need a specialized kernel to color-convert? Or we put those frames we
         # can have on NV12 - but for 444 it's a problem becaus ewe can't convert

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3454,6 +3454,17 @@ class TestBlocks:
         if device == "cuda" and video is DISCARD_FIRST_KEYFRAME_VIDEO:
             pytest.skip("Blocks pipeline does not handle this asset on CUDA yet.")
 
+        if (
+            video
+            in (
+                TESTSRC2_ODD_WIDTH_VP9,
+                TESTSRC2_ODD_HEIGHT_VP9,
+                TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9,
+            )
+            and ffmpeg_major_version == 4
+        ):
+            pytest.skip("FFmpeg 4 returns one more frame")
+
         got = self._to_frame_batch(decode_method(self, video.path, device))
         ref = VideoDecoder(video.path, device=device).get_all_frames()
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3575,9 +3575,8 @@ class TestBlocks:
         planes, pix_fmt, colorspace, color_range = frame.materialize()
 
         assert isinstance(pix_fmt, str) and pix_fmt
-        # TODO_NOW Really? int??
-        assert isinstance(colorspace, int)
-        assert isinstance(color_range, int)
+        assert colorspace in ("bt709", "bt2020nc", "smpte170m", "unknown")
+        assert color_range in ("tv", "pc", "unknown")  # FFmpeg has only these
 
         # All planes are 2D views living on the frame's own device.
         # TODO_API_BREAKDOWN P1: Can there be more planes? Should test?

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3644,6 +3644,7 @@ class TestBlocks:
     def test_materialize_planes_outlive_frame(self, video, device):
         # The views keep the frame alive, so they stay valid (readable and
         # writable) after the DecodedFrame they came from is dropped.
+        # grep for this test name to see associated comment in the code.
         frame, _ = self._first_frame(video.path, device)
         planes, *_ = frame.materialize()
         saved = [plane.clone() for plane in planes]

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3419,6 +3419,20 @@ class TestBlocks:
             # the CPU-fallback path: the decoder hands out CPU frames and the
             # converter has to notice and upload them itself.
             H265_VIDEO,
+            # Video with a non-zero start time: exercises pts propagation.
+            TEST_NON_ZERO_START,
+            # Odd dimensions: NVDEC decodes to even-aligned surfaces, so the
+            # converter has to crop back to the real width/height.
+            TESTSRC2_ODD_WIDTH_VP9,
+            TESTSRC2_ODD_HEIGHT_VP9,
+            TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9,
+            # yuv444p (odd dims too). NVDEC can't decode 4:4:4, so on CUDA these
+            # take the CPU-fallback path.
+            TESTSRC2_ODD_WIDTH_444,
+            TESTSRC2_ODD_HEIGHT_444,
+            TESTSRC2_ODD_HEIGHT_AND_WIDTH_444,
+            # First keyframe is marked AV_PKT_FLAG_DISCARD by an mp4 edit list.
+            DISCARD_FIRST_KEYFRAME_VIDEO,
         ),
     )
     @pytest.mark.parametrize(
@@ -3433,6 +3447,12 @@ class TestBlocks:
     )
     @pytest.mark.parametrize("device", _block_devices())
     def test_matches_video_decoder(self, video, decode_method, device):
+        # TODO_API_BREAKDOWN P0: this fails on CUDA and must be fixed. The blocks
+        # Demuxer doesn't honor AV_PKT_FLAG_DISCARD (unlike SingleStreamDecoder),
+        # so it emits the extra frames trimmed away by the mp4 edit list.
+        if device == "cuda" and video is DISCARD_FIRST_KEYFRAME_VIDEO:
+            pytest.skip("Blocks pipeline does not handle this asset on CUDA yet.")
+
         got = self._to_frame_batch(decode_method(self, video.path, device))
         ref = VideoDecoder(video.path, device=device).get_all_frames()
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3573,7 +3573,7 @@ class TestBlocks:
         torch.testing.assert_close(got.data, ref.data, atol=0, rtol=0)
 
     def _first_frame(self, path, device):
-        # The first DecodedFrame of a video (demux + decode on this thread).
+        # The first DecodedFrame of a video
         demuxer, decoder, converter = self._make_blocks(path, device)
         frame = next(self._decode(decoder, self._demux(demuxer)))
         return frame, converter
@@ -3591,9 +3591,13 @@ class TestBlocks:
 
         # All planes are 2D views living on the frame's own device.
         for plane in planes:
+            # TODO_API_BREAKDOWN P0 Why 2??
             assert plane.ndim == 2
             assert plane.device.type == frame.device
 
+        # TODO_API_BREAKDOWN P0 getting uint16 isn't expected - we never go
+        # through P016 on CUDA, for example. There's a TODO about handling HDr
+        # in general, should figure that out then.
         expected_dtype = torch.uint16 if _is_high_depth(pix_fmt) else torch.uint8
         assert all(plane.dtype == expected_dtype for plane in planes)
 
@@ -3681,9 +3685,14 @@ class TestBlocks:
     @pytest.mark.needs_cuda
     @pytest.mark.parametrize("video", (H265_VIDEO, TESTSRC2_ODD_HEIGHT_AND_WIDTH_444))
     def test_materialize_cpu_fallback_stays_on_cpu(self, video):
-        # NVDEC can't decode these (too small / 4:4:4), so a CUDA decoder falls
-        # back to CPU decoding: the samples are in host memory and materialize()
-        # must expose CPU views even though the decoder is CUDA.
+        # TODO_API_BREAKDOWN P0: This may not be what we want. We probalby want
+        # to output CUDA data.  But how? Do we put the YUV420 on CUDA? Then we
+        # need a specialized kernel to color-convert? Or we put those frames we
+        # can have on NV12 - but for 444 it's a problem becaus ewe can't convert
+        # them to NV12, so we'd need a 444 color-conversion kernel anyway. So
+        # all frames would be NV12 except *some* (the 444 ones)?
+        # Unclear what to do here honestly. Maybe outputting CPU frames is
+        # actually justifiable?
         frame, _ = self._first_frame(video.path, "cuda")
         assert frame.device == "cpu"
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -7,6 +7,7 @@
 import concurrent.futures
 import contextlib
 import gc
+import math
 import queue
 import threading
 from functools import partial
@@ -3279,6 +3280,41 @@ def _block_devices():
     return ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
 
 
+# Videos spanning the pixel-format axes materialize() has to handle: 4:2:0 vs
+# 4:4:4 chroma, even vs odd dims (chroma rounds up), and 8- vs 10-/12-bit
+# (uint8 vs uint16 planes). All are YUV, so planes are (Y, U, V).
+_MATERIALIZE_VIDEOS = (
+    NASA_VIDEO,  # yuv420p, 8-bit, even dims
+    TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9,  # yuv420p, 8-bit, odd dims
+    TESTSRC2_ODD_HEIGHT_AND_WIDTH_444,  # yuv444p, 8-bit, full-res chroma
+    TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9_10BIT,  # yuv420p10le, 10-bit -> uint16
+    TEST_SRC_2_12BIT_HDR,  # yuv420p12le, 12-bit -> uint16
+)
+
+
+def _chroma_log2(pix_fmt):
+    # (log2 horizontal, log2 vertical) chroma subsampling of a YUV pixel format.
+    if "444" in pix_fmt:
+        return (0, 0)
+    if "422" in pix_fmt or "nv16" in pix_fmt:
+        return (1, 0)
+    # 4:2:0 planar (yuv420p...) and semi-planar (nv12, p010, p016).
+    return (1, 1)
+
+
+def _is_high_depth(pix_fmt):
+    # Whether samples need uint16. nv12/nv21 contain "12"/"21" but are 8-bit.
+    if pix_fmt in ("nv12", "nv21", "nv16", "nv24"):
+        return False
+    return any(token in pix_fmt for token in ("10", "12", "14", "16"))
+
+
+def _planes_equal(a, b):
+    # Elementwise equality that also works for uint16 (some comparison kernels
+    # aren't implemented for it, so compare as int32).
+    return bool((a.to(torch.int32) == b.to(torch.int32)).all())
+
+
 class TestBlocks:
 
     @pytest.mark.parametrize("device", _block_devices())
@@ -3501,6 +3537,125 @@ class TestBlocks:
             got = self._to_frame_batch(self._decode_sequential(NASA_VIDEO.path, device))
         ref = self._to_frame_batch(self._decode_sequential(NASA_VIDEO.path, device))
         torch.testing.assert_close(got.data, ref.data, atol=0, rtol=0)
+
+    def _first_frame(self, path, device):
+        # The first DecodedFrame of a video (demux + decode on this thread).
+        demuxer, decoder, converter = self._make_blocks(path, device)
+        frame = next(self._decode(decoder, self._demux(demuxer)))
+        return frame, converter
+
+    @pytest.mark.parametrize("video", _MATERIALIZE_VIDEOS)
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_materialize_structure(self, video, device):
+        # planes shape/dtype/device and the accompanying metadata.
+        frame, converter = self._first_frame(video.path, device)
+        planes, pix_fmt, colorspace, color_range = frame.materialize()
+
+        assert isinstance(pix_fmt, str) and pix_fmt
+        assert isinstance(colorspace, int)
+        assert isinstance(color_range, int)
+
+        # All planes are 2D views living on the frame's own device.
+        for plane in planes:
+            assert plane.ndim == 2
+            assert plane.device.type == frame.device
+
+        expected_dtype = torch.uint16 if _is_high_depth(pix_fmt) else torch.uint8
+        assert all(plane.dtype == expected_dtype for plane in planes)
+
+        # The luma plane matches the color-converted frame's spatial size...
+        height, width = converter.convert(frame).data.shape[1:]
+        assert tuple(planes[0].shape) == (height, width)
+
+        # ...and the two chroma planes are subsampled per the pixel format,
+        # rounding up for odd dimensions (as AV_CEIL_RSHIFT does in C++).
+        assert len(planes) == 3  # every asset here is YUV without alpha
+        log2w, log2h = _chroma_log2(pix_fmt)
+        expected_chroma = (
+            math.ceil(height / (1 << log2h)),
+            math.ceil(width / (1 << log2w)),
+        )
+        for chroma in planes[1:]:
+            assert tuple(chroma.shape) == expected_chroma
+
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_materialize_mutation_visible_in_color_convert(self, device):
+        # materialize() returns views into the frame's own memory, so editing
+        # them and color-converting the SAME frame reflects the edit.
+        frame, converter = self._first_frame(NASA_VIDEO.path, device)
+
+        original = converter.convert(frame).data.clone()
+
+        planes, *_ = frame.materialize()
+        for value, plane in zip((50, 100, 150), planes):
+            plane.fill_(value)  # overwrite Y, U, V with distinct constants
+        edited = converter.convert(frame).data
+
+        # The edit changed the output...
+        assert not torch.equal(edited, original)
+        # ...and since every plane is now spatially constant, each RGB channel
+        # is a single color across all pixels.
+        for channel in edited:
+            assert channel.min().item() == channel.max().item()
+
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_materialize_is_a_view_not_a_copy(self, device):
+        # Two independent materialize() calls view the SAME underlying buffer,
+        # so a write through one is visible through the other.
+        frame, _ = self._first_frame(NASA_VIDEO.path, device)
+        planes_a, *_ = frame.materialize()
+        planes_b, *_ = frame.materialize()
+
+        original = int(planes_a[0][0, 0].item())
+        planes_a[0][0, 0] = original ^ 0xFF
+        assert int(planes_b[0][0, 0].item()) == (original ^ 0xFF)
+
+    @pytest.mark.parametrize("video", _MATERIALIZE_VIDEOS)
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_materialize_planes_outlive_frame(self, video, device):
+        # The views keep the frame alive, so they stay valid (readable and
+        # writable) after the DecodedFrame they came from is dropped.
+        frame, _ = self._first_frame(video.path, device)
+        planes, *_ = frame.materialize()
+        saved = [plane.clone() for plane in planes]
+
+        del frame
+        gc.collect()
+
+        for plane, snapshot in zip(planes, saved):
+            assert _planes_equal(plane, snapshot)
+        planes[0][0, 0] = 0  # still writable: the memory is valid
+
+    @pytest.mark.parametrize("video", (NASA_VIDEO, BT709_FULL_RANGE))
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_materialize_neutral_chroma_is_grayscale(self, video, device):
+        # Forcing the chroma planes to neutral (128) yields a gray image
+        # (R == G == B). This pins down which planes are the chroma components
+        # and that the writes land in the buffer the converter reads.
+        frame, converter = self._first_frame(video.path, device)
+        planes, pix_fmt, *_ = frame.materialize()
+        assert planes[0].dtype == torch.uint8  # both assets are 8-bit
+
+        for chroma in planes[1:]:
+            chroma.fill_(128)
+
+        r, g, b = converter.convert(frame).data.to(torch.int16)
+        # atol=1 for integer rounding in the CUDA color-conversion kernel.
+        torch.testing.assert_close(r, g, atol=1, rtol=0)
+        torch.testing.assert_close(g, b, atol=1, rtol=0)
+
+    @pytest.mark.needs_cuda
+    @pytest.mark.parametrize("video", (H265_VIDEO, TESTSRC2_ODD_HEIGHT_AND_WIDTH_444))
+    def test_materialize_cpu_fallback_stays_on_cpu(self, video):
+        # NVDEC can't decode these (too small / 4:4:4), so a CUDA decoder falls
+        # back to CPU decoding: the samples are in host memory and materialize()
+        # must expose CPU views even though the decoder is CUDA.
+        frame, _ = self._first_frame(video.path, "cuda")
+        assert frame.device == "cpu"
+
+        planes, pix_fmt, *_ = frame.materialize()
+        assert pix_fmt != "nv12"
+        assert all(plane.device.type == "cpu" for plane in planes)
 
 
 # Small helpers to avoid having to always specify the same skip marks and decode_fn


### PR DESCRIPTION
This will requires lots of follow-ups to align the CPU and GPU behavior but the core functionality is there. Nothing substantial other than the ownership model of the exposed YUV tensors: each of the YUV planes is associated with a copy of frame handle tensor, which owns the underlying AVFrame and its data. As long as one of these copies live, the AVFrame lives.