### PR TITLE
HDR-correct dtype handling for the Blocks API

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -209,7 +209,8 @@ std::optional<cudaVideoCodec> validate_codec_support(AVCodecID codec_id) {
 std::optional<cudaVideoSurfaceFormat> get_nvdec_surface_format(
     const StableDevice& device,
     const SharedAVCodecContext& codec_context,
-    OutputDtype output_dtype) {
+    OutputDtype output_dtype,
+    DecodePrecision decode_precision) {
   // Return the surface format to use for NVDEC decoding if the stream is
   // supported, or nullopt to fall back to CPU.
 
@@ -256,7 +257,12 @@ std::optional<cudaVideoSurfaceFormat> get_nvdec_surface_format(
     return std::nullopt;
   }
 
-  auto preferred_format = get_preferred_surface_format(output_dtype);
+  // NATIVE keeps the source's bit depth: P016 for 10-/12-bit content, NV12 for
+  // 8-bit. This is what the CPU decoder does, so it's what makes the two agree.
+  auto preferred_format = (decode_precision == DecodePrecision::NATIVE)
+      ? (bit_depth_minus8 > 0 ? cudaVideoSurfaceFormat_P016
+                              : cudaVideoSurfaceFormat_NV12)
+      : get_preferred_surface_format(output_dtype);
   if ((caps.nOutputFormatMask >> preferred_format) & 1) {
     return preferred_format;
   }
@@ -378,7 +384,11 @@ void BetaCudaDeviceInterface::initialize_video_decoding(
   output_dtype_ = video_stream_options.output_dtype;
 
   auto maybe_surface_format = nvcuvid_available_
-      ? get_nvdec_surface_format(device_, codec_context_, output_dtype_)
+      ? get_nvdec_surface_format(
+            device_,
+            codec_context_,
+            output_dtype_,
+            video_stream_options.decode_precision)
       : std::nullopt;
 
   if (!maybe_surface_format.has_value()) {
@@ -912,6 +922,8 @@ void BetaCudaDeviceInterface::make_frame_standalone(UniqueAVFrame& av_frame) {
 
   auto attached_data = new StandAloneFrameAttachedData();
   attached_data->producer_stream = current_stream;
+  attached_data->bit_depth =
+      static_cast<int>(video_format_.bit_depth_luma_minus8) + 8;
 
   if (!is_cpu_fallback(av_frame->format)) {
     // The amount of bytes an NV12 image takes is:
@@ -1194,6 +1206,7 @@ void BetaCudaDeviceInterface::convert_av_frame_to_frame_output(
       "Expected NV12 or P016LE format frame");
 
   cudaStream_t producer_stream;
+  std::optional<int> standalone_bit_depth;
   if (mode() == Mode::ColorConverterOnly) {
     STD_TORCH_CHECK(
         av_frame.opaque_ref != nullptr,
@@ -1202,6 +1215,9 @@ void BetaCudaDeviceInterface::convert_av_frame_to_frame_output(
     auto attached_data = reinterpret_cast<StandAloneFrameAttachedData*>(
         av_frame.opaque_ref->data);
     producer_stream = attached_data->producer_stream;
+    // video_format_ is only populated while decoding, so a standalone
+    // ColorConverter has to take the source's bit depth from the frame.
+    standalone_bit_depth = attached_data->bit_depth;
   } else {
     producer_stream = get_current_cuda_stream(device_.index());
   }
@@ -1213,9 +1229,10 @@ void BetaCudaDeviceInterface::convert_av_frame_to_frame_output(
     bool is_p016 = (gpu_frame.format == AV_PIX_FMT_P016LE);
     int bit_depth = 8;
     if (is_p016) {
-      bit_depth = cpu_fallback
-          ? codec_context_->bits_per_raw_sample
-          : static_cast<int>(video_format_.bit_depth_luma_minus8) + 8;
+      bit_depth = standalone_bit_depth.value_or(
+          cpu_fallback
+              ? codec_context_->bits_per_raw_sample
+              : static_cast<int>(video_format_.bit_depth_luma_minus8) + 8);
     }
     return convert_yuv_frame_to_rgb(
         gpu_frame,
@@ -1225,6 +1242,7 @@ void BetaCudaDeviceInterface::convert_av_frame_to_frame_output(
         original_dims,
         is_p016,
         bit_depth,
+        output_dtype_,
         cached_color_matrix_);
   };
 

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -36,6 +36,7 @@ namespace facebook::torchcodec {
 struct StandAloneFrameAttachedData {
   cudaStream_t producer_stream = nullptr;
   torch::stable::Tensor storage;
+  int bit_depth = 8;
 };
 
 class BetaCudaDeviceInterface : public DeviceInterface {

--- a/src/torchcodec/_core/ColorConverter.cpp
+++ b/src/torchcodec/_core/ColorConverter.cpp
@@ -15,15 +15,47 @@
 
 namespace facebook::torchcodec {
 
-ColorConverter::ColorConverter(const StableDevice& device) {
+namespace {
+
+// Mirrors SingleStreamDecoder::maybe_permute_and_convert_to_float32().
+torch::stable::Tensor maybe_convert_to_float32(
+    torch::stable::Tensor& data,
+    OutputDtype output_dtype) {
+  if (output_dtype != OutputDtype::FLOAT32) {
+    return data;
+  }
+  bool is_uint16 = data.scalar_type() == kStableUInt16;
+  double max_val = is_uint16 ? 65535.0 : 255.0;
+  auto as_float = torch::stable::to(data, kStableFloat32);
+  return stable_div(as_float, max_val);
+}
+
+} // namespace
+
+ColorConverter::ColorConverter(
+    const StableDevice& device,
+    OutputDtypeConfig output_dtype_config)
+    : device_(device), output_dtype_config_(output_dtype_config) {
   device_interface_ = create_device_interface(device);
   STD_TORCH_CHECK(
       device_interface_ != nullptr,
       "Failed to create device interface. This should never happen, please report.");
 
+  // AUTO needs a frame to resolve; the first one may re-initialize us.
+  initialize_for_output_dtype(
+      output_dtype_config == OutputDtypeConfig::FLOAT32 ? OutputDtype::FLOAT32
+                                                        : OutputDtype::UINT8);
+}
+
+void ColorConverter::initialize_for_output_dtype(OutputDtype output_dtype) {
+  if (initialized_output_dtype_.has_value() &&
+      *initialized_output_dtype_ == output_dtype) {
+    return;
+  }
+
   VideoStreamOptions options;
-  options.output_dtype = OutputDtype::UINT8; // dtype not exposed yet
-  options.device = device;
+  options.output_dtype = output_dtype;
+  options.device = device_;
 
   // TODO_API_BREAKDOWN P1 It seems unnatural that the color-converter needs its
   // own device_interface_, but at the same time the color-conversion *must* be
@@ -32,13 +64,34 @@ ColorConverter::ColorConverter(const StableDevice& device) {
   std::vector<std::unique_ptr<Transform>> no_transforms;
   device_interface_->initialize_color_conversion(
       options, no_transforms, /*resized_output_dims=*/std::nullopt);
+  initialized_output_dtype_ = output_dtype;
+}
+
+OutputDtype ColorConverter::resolve_output_dtype(
+    const AVFrame& av_frame) const {
+  switch (output_dtype_config_) {
+    case OutputDtypeConfig::UINT8:
+      return OutputDtype::UINT8;
+    case OutputDtypeConfig::FLOAT32:
+      return OutputDtype::FLOAT32;
+    case OutputDtypeConfig::AUTO: {
+      const AVPixFmtDescriptor* desc =
+          av_pix_fmt_desc_get(static_cast<AVPixelFormat>(av_frame.format));
+      return (desc != nullptr && desc->comp[0].depth > 8) ? OutputDtype::FLOAT32
+                                                          : OutputDtype::UINT8;
+    }
+  }
+  return OutputDtype::UINT8;
 }
 
 torch::stable::Tensor ColorConverter::convert(const AVFrame& av_frame) {
+  OutputDtype output_dtype = resolve_output_dtype(av_frame);
+  initialize_for_output_dtype(output_dtype);
+
   FrameOutput frame_output;
   device_interface_->convert_av_frame_to_frame_output(
       av_frame, frame_output, std::nullopt);
-  return frame_output.data;
+  return maybe_convert_to_float32(frame_output.data, output_dtype);
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/ColorConverter.h
+++ b/src/torchcodec/_core/ColorConverter.h
@@ -7,23 +7,32 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 #include "DeviceInterface.h"
 #include "FFMPEGCommon.h"
 #include "StableABICompat.h"
+#include "StreamOptions.h"
 
 namespace facebook::torchcodec {
 
 class FORCE_PUBLIC_VISIBILITY ColorConverter {
  public:
   explicit ColorConverter(
-      const StableDevice& device = StableDevice(kStableCPU));
+      const StableDevice& device = StableDevice(kStableCPU),
+      OutputDtypeConfig output_dtype_config = OutputDtypeConfig::UINT8);
 
   torch::stable::Tensor convert(const AVFrame& av_frame);
 
  private:
+  OutputDtype resolve_output_dtype(const AVFrame& av_frame) const;
+  void initialize_for_output_dtype(OutputDtype output_dtype);
+
   std::unique_ptr<DeviceInterface> device_interface_;
+  StableDevice device_;
+  OutputDtypeConfig output_dtype_config_;
+  std::optional<OutputDtype> initialized_output_dtype_;
 };
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -347,6 +347,7 @@ void CudaDeviceInterface::convert_av_frame_to_frame_output(
       FrameDims(av_frame.height, av_frame.width),
       /*isP016=*/false,
       /*bitDepth=*/8,
+      video_stream_options_.output_dtype,
       cached_color_matrix_);
 }
 

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -72,13 +72,19 @@ PacketDecoder::PacketDecoder(
   device_interface_->initialize(codec_context_);
 
   VideoStreamOptions options;
-  // TODO_API_BREAKDOWN P1: Need to design and figure out behavior of Blocks
-  // with HDR data.
-  options.output_dtype = OutputDtype::UINT8; // dtype not exposed yet
+  // This block hands frames to the caller untouched, so it must not discard
+  // precision a later ColorConverter or materialize() might want.
+  options.decode_precision = DecodePrecision::NATIVE;
   options.device = device;
 
   device_interface_->initialize_video_decoding(
       stream, demuxer.format_context(), options);
+
+  // From the codec context: a hardware decoder may use a wider container.
+  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(codec_context_->pix_fmt);
+  if (desc != nullptr) {
+    bit_depth_ = static_cast<int64_t>(desc->comp[0].depth);
+  }
 }
 
 int PacketDecoder::send_packet(AVPacket* packet) {
@@ -108,6 +114,7 @@ int PacketDecoder::receive_frame(UniqueAVFrame& av_frame) {
 FramePlanes frame_to_planes(
     const AVFrame& av_frame,
     const StableDevice& device,
+    int64_t stream_bit_depth,
     const torch::stable::Tensor& tensor_handle) {
   auto pix_fmt = static_cast<AVPixelFormat>(av_frame.format);
   const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(pix_fmt);
@@ -134,6 +141,14 @@ FramePlanes frame_to_planes(
   result.pix_fmt = fmt_name;
   result.colorspace = colorspace_name ? colorspace_name : "unknown";
   result.color_range = color_range_name ? color_range_name : "unknown";
+
+  // Where container and source depth differ, the samples sit in the high bits.
+  int64_t container_depth = static_cast<int64_t>(desc->comp[0].depth);
+  result.bit_depth =
+      (stream_bit_depth > 0 && stream_bit_depth <= container_depth)
+      ? stream_bit_depth
+      : container_depth;
+  result.sample_shift = container_depth - result.bit_depth;
 
   for (int c = 0; c < desc->nb_components; ++c) {
     const AVComponentDescriptor& comp = desc->comp[c];

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -58,10 +58,16 @@ class FORCE_PUBLIC_VISIBILITY PacketDecoder {
     return time_base_;
   }
 
+  // Of the source, not of the frames: NVDEC decodes 10-bit into P016 surfaces.
+  int64_t bit_depth() const {
+    return bit_depth_;
+  }
+
  private:
   std::unique_ptr<DeviceInterface> device_interface_;
   SharedAVCodecContext codec_context_;
   AVRational time_base_ = {};
+  int64_t bit_depth_ = 8;
 };
 
 // A decoded frame's own samples, before any color conversion.
@@ -73,11 +79,16 @@ struct FramePlanes {
   std::string pix_fmt;
   std::string colorspace;
   std::string color_range;
+  int64_t bit_depth = 8;
+  // Right-shift to recover a sample's value: P016 is msb-aligned, planar
+  // yuv420p10le is not.
+  int64_t sample_shift = 0;
 };
 
 FORCE_PUBLIC_VISIBILITY FramePlanes frame_to_planes(
     const AVFrame& av_frame,
     const StableDevice& device,
+    int64_t stream_bit_depth,
     const torch::stable::Tensor& tensor_handle);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/StreamOptions.h
+++ b/src/torchcodec/_core/StreamOptions.h
@@ -36,6 +36,12 @@ enum class OutputDtype { UINT8, FLOAT32 };
 // AUTO: Output uint8 for SDR (<=8-bit) sources, float32 for HDR (>8-bit).
 enum class OutputDtypeConfig { UINT8, FLOAT32, AUTO };
 
+// Precision of the decoded frames, before color conversion. Only hardware
+// decoders can be asked for this; software decoders are always NATIVE.
+// OUTPUT_DRIVEN decodes HDR into 8-bit surfaces when uint8 output is requested,
+// which is faster but truncates before color conversion.
+enum class DecodePrecision { OUTPUT_DRIVEN, NATIVE };
+
 struct VideoStreamOptions {
   VideoStreamOptions() {}
 
@@ -69,6 +75,8 @@ struct VideoStreamOptions {
   // Set by addVideoStream() after resolving AUTO. All downstream code should
   // read this field.
   OutputDtype output_dtype = OutputDtype::UINT8;
+
+  DecodePrecision decode_precision = DecodePrecision::OUTPUT_DRIVEN;
 
   // Encoding options
   std::optional<std::string> codec;

--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -38,6 +38,7 @@ FFMPEG_OP_NAMES = frozenset(
         "_blocks_create_color_converter",
         "_blocks_convert_frame",
         "_blocks_frame_to_planes",
+        "_blocks_packet_decoder_bit_depth",
         "_test_frame_pts_equality",
         "_get_container_json_metadata",
         "_get_key_frame_indices",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -113,6 +113,9 @@ _blocks_create_color_converter = (
 )
 _blocks_convert_frame = torch.ops.torchcodec_ns._blocks_convert_frame.default
 _blocks_frame_to_planes = torch.ops.torchcodec_ns._blocks_frame_to_planes.default
+_blocks_packet_decoder_bit_depth = (
+    torch.ops.torchcodec_ns._blocks_packet_decoder_bit_depth.default
+)
 
 _test_frame_pts_equality = torch.ops.torchcodec_ns._test_frame_pts_equality.default
 _get_container_json_metadata = (

--- a/src/torchcodec/_core/color_conversion.cpp
+++ b/src/torchcodec/_core/color_conversion.cpp
@@ -196,9 +196,16 @@ torch::stable::Tensor convert_yuv_frame_to_rgb(
     const FrameDims& output_dims,
     bool is_p016,
     int bit_depth,
+    OutputDtype requested_dtype,
     CachedColorMatrix& cached_color_matrix) {
-  float out_scale = is_p016 ? 65535.0f : 255.0f;
-  OutputDtype out_dtype = is_p016 ? OutputDtype::FLOAT32 : OutputDtype::UINT8;
+  // The kernel writes the same sample type it reads, so P016 always lands in a
+  // uint16 buffer that we narrow afterwards.
+  // TODO: decouple the kernel template's in/out types to fuse this.
+  bool narrow_to_uint8 = is_p016 && requested_dtype == OutputDtype::UINT8;
+
+  float out_scale = (is_p016 && !narrow_to_uint8) ? 65535.0f : 255.0f;
+  OutputDtype buffer_dtype =
+      is_p016 ? OutputDtype::FLOAT32 : OutputDtype::UINT8;
 
   // Dimensions may be odd (NVDEC display area for VP9 etc.). NV12/P016
   // color conversion requires even dimensions, so we round up to even
@@ -210,15 +217,18 @@ torch::stable::Tensor convert_yuv_frame_to_rgb(
   int out_width = output_dims.width;
   bool needs_crop = (out_height != even_height) || (out_width != even_width);
 
+  bool use_pre_alloc_as_dst = pre_allocated_output_tensor.has_value() &&
+      !needs_crop && !narrow_to_uint8;
+
   torch::stable::Tensor dst;
-  if (needs_crop) {
-    dst = allocate_empty_hwc_tensor(
-        FrameDims(even_height, even_width), device, out_dtype);
-  } else if (pre_allocated_output_tensor.has_value()) {
+  if (use_pre_alloc_as_dst) {
     dst = pre_allocated_output_tensor.value();
   } else {
     dst = allocate_empty_hwc_tensor(
-        FrameDims(out_height, out_width), device, out_dtype);
+        needs_crop ? FrameDims(even_height, even_width)
+                   : FrameDims(out_height, out_width),
+        device,
+        buffer_dtype);
   }
 
   // TODO_API_BREAKDOWN P1: This may not be the semantic that we want: this will
@@ -248,6 +258,7 @@ torch::stable::Tensor convert_yuv_frame_to_rgb(
         av_frame.linesize[1],
         validate_int64_to_int(dst.stride(0) * 2, "dst.stride(0)*2"),
         bit_depth,
+        out_scale,
         cached_color_matrix.matrix,
         stream);
   } else {
@@ -260,6 +271,7 @@ torch::stable::Tensor convert_yuv_frame_to_rgb(
         av_frame.linesize[0],
         av_frame.linesize[1],
         validate_int64_to_int(dst.stride(0), "dst.stride(0)"),
+        out_scale,
         cached_color_matrix.matrix,
         stream);
   }
@@ -272,11 +284,15 @@ torch::stable::Tensor convert_yuv_frame_to_rgb(
       dst = torch::stable::narrow(dst, /*dim=*/1, /*start=*/0, out_width);
       dst = torch::stable::contiguous(dst);
     }
-    if (pre_allocated_output_tensor.has_value()) {
-      torch::stable::copy_(pre_allocated_output_tensor.value(), dst);
-      return pre_allocated_output_tensor.value();
-    }
-    return dst;
+  }
+
+  if (narrow_to_uint8) {
+    dst = torch::stable::to(dst, kStableUInt8);
+  }
+
+  if (pre_allocated_output_tensor.has_value() && !use_pre_alloc_as_dst) {
+    torch::stable::copy_(pre_allocated_output_tensor.value(), dst);
+    return pre_allocated_output_tensor.value();
   }
   return dst;
 }

--- a/src/torchcodec/_core/color_conversion.cu
+++ b/src/torchcodec/_core/color_conversion.cu
@@ -38,9 +38,8 @@ __device__ void write_pair_of_rgb_pixels(
     float v,
     T* rgb_plane_to_write,
     int bit_shift,
+    float clamp_max,
     const ColorMatrix& cm) {
-  constexpr float clamp_max = sizeof(T) == 1 ? 255.0f : 65535.0f;
-
   float ya = static_cast<float>(yayb.x >> bit_shift);
   float yb = static_cast<float>(yayb.y >> bit_shift);
 
@@ -97,6 +96,7 @@ __global__ void yuv_to_rgb_kernel(
     int uv_pitch_elements,
     int rgb_pitch_elements,
     int bit_shift,
+    float clamp_max,
     const ColorMatrix cm) {
   // The kernel operates on 2x2 blocks, so it's called H / 2 * W / 2 times.
   // We have to multiply back by 2 to retrieve the output pixel coordinates x
@@ -122,10 +122,10 @@ __global__ void yuv_to_rgb_kernel(
 
   T* rgb_plane_to_write = rgb_output + y * rgb_pitch_elements + x * 3;
   write_pair_of_rgb_pixels<T, Vec2T>(
-      y1y2, u, v, rgb_plane_to_write, bit_shift, cm);
+      y1y2, u, v, rgb_plane_to_write, bit_shift, clamp_max, cm);
   rgb_plane_to_write += rgb_pitch_elements; // go to next line
   write_pair_of_rgb_pixels<T, Vec2T>(
-      y3y4, u, v, rgb_plane_to_write, bit_shift, cm);
+      y3y4, u, v, rgb_plane_to_write, bit_shift, clamp_max, cm);
 }
 
 void launch_nv12_to_rgb_kernel(
@@ -137,6 +137,7 @@ void launch_nv12_to_rgb_kernel(
     int y_pitch,
     int uv_pitch,
     int rgb_pitch,
+    float clamp_max,
     const float color_matrix[3][4],
     cudaStream_t stream) {
   const auto& cm = *reinterpret_cast<const ColorMatrix*>(color_matrix);
@@ -156,6 +157,7 @@ void launch_nv12_to_rgb_kernel(
       uv_pitch,
       rgb_pitch,
       0, // bitShift = 0 for NV12
+      clamp_max,
       cm);
 }
 
@@ -169,6 +171,7 @@ void launch_p016_to_rgb16_kernel(
     int uv_pitch,
     int rgb_pitch,
     int bit_depth,
+    float clamp_max,
     const float color_matrix[3][4],
     cudaStream_t stream) {
   const auto& cm = *reinterpret_cast<const ColorMatrix*>(color_matrix);
@@ -193,6 +196,7 @@ void launch_p016_to_rgb16_kernel(
       uv_pitch_elements,
       rgb_pitch_elements,
       bit_shift,
+      clamp_max,
       cm);
 }
 

--- a/src/torchcodec/_core/color_conversion.h
+++ b/src/torchcodec/_core/color_conversion.h
@@ -61,6 +61,7 @@ void launch_nv12_to_rgb_kernel(
     int y_pitch,
     int uv_pitch,
     int rgb_pitch,
+    float clamp_max,
     const float color_matrix[3][4],
     cudaStream_t stream);
 
@@ -74,6 +75,7 @@ void launch_p016_to_rgb16_kernel(
     int uv_pitch,
     int rgb_pitch,
     int bit_depth,
+    float clamp_max,
     const float color_matrix[3][4],
     cudaStream_t stream);
 
@@ -83,6 +85,8 @@ void launch_p016_to_rgb16_kernel(
 // bitDepth: 8 for NV12, actual bit depth (10 or 12) for P016.
 // outputDims: desired output size; if the frame was rounded up to even
 //   dimensions, the result is cropped back to outputDims.
+// requestedDtype: P016 destined for UINT8 is narrowed here; FLOAT32 callers get
+//   the uint16 tensor and normalize it themselves.
 torch::stable::Tensor convert_yuv_frame_to_rgb(
     const AVFrame& av_frame,
     const StableDevice& device,
@@ -91,6 +95,7 @@ torch::stable::Tensor convert_yuv_frame_to_rgb(
     const FrameDims& output_dims,
     bool is_p016,
     int bit_depth,
+    OutputDtype requested_dtype,
     CachedColorMatrix& cached_color_matrix);
 
 // Compute the RGB -> YUV color conversion matrix (for encoding).

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -83,10 +83,12 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def("_blocks_packet_decoder_send_eof(Tensor(a!) decoder) -> int");
   m.def(
       "_blocks_packet_decoder_receive_frame(Tensor(a!) decoder) -> (Tensor, int, float, float, str)");
-  m.def("_blocks_create_color_converter(str device=\"cpu\") -> Tensor");
+  m.def(
+      "_blocks_create_color_converter(str device=\"cpu\", str output_dtype=\"uint8\") -> Tensor");
   m.def("_blocks_convert_frame(Tensor(a!) converter, Tensor frame) -> Tensor");
   m.def(
-      "_blocks_frame_to_planes(Tensor frame, str device) -> (Tensor, Tensor, Tensor, Tensor, str, str, str)");
+      "_blocks_frame_to_planes(Tensor frame, str device, int bit_depth) -> (Tensor, Tensor, Tensor, Tensor, str, str, str, int, int)");
+  m.def("_blocks_packet_decoder_bit_depth(Tensor decoder) -> int");
   m.def("_get_key_frame_indices(Tensor(a!) decoder) -> Tensor");
   m.def("get_json_metadata(Tensor(a!) decoder) -> str");
   m.def("get_container_json_metadata(Tensor(a!) decoder) -> str");
@@ -882,9 +884,27 @@ OpsReceiveFrameOutput _blocks_packet_decoder_receive_frame(
       device);
 }
 
-torch::stable::Tensor _blocks_create_color_converter(std::string device) {
+OutputDtypeConfig parse_output_dtype_config(const std::string& output_dtype) {
+  if (output_dtype == "uint8") {
+    return OutputDtypeConfig::UINT8;
+  } else if (output_dtype == "float32") {
+    return OutputDtypeConfig::FLOAT32;
+  } else if (output_dtype == "auto") {
+    return OutputDtypeConfig::AUTO;
+  }
+  STD_TORCH_CHECK(
+      false,
+      "Invalid output_dtype=",
+      output_dtype,
+      ". Supported values are: uint8, float32, auto.");
+}
+
+torch::stable::Tensor _blocks_create_color_converter(
+    std::string device,
+    std::string output_dtype) {
   validate_device_interface(device);
-  auto converter = std::make_unique<ColorConverter>(StableDevice(device));
+  auto converter = std::make_unique<ColorConverter>(
+      StableDevice(device), parse_output_dtype_config(output_dtype));
   return wrap_pointer_to_tensor<ColorConverter>(std::move(converter));
 }
 
@@ -903,14 +923,17 @@ using OpsFrameToPlanesOutput = std::tuple<
     torch::stable::Tensor,
     std::string, // pixel-format
     std::string, // colorspace
-    std::string>; // color range
+    std::string, // color range
+    int64_t, // bit depth
+    int64_t>; // sample shift
 
 OpsFrameToPlanesOutput _blocks_frame_to_planes(
     torch::stable::Tensor& tensor_handle,
-    std::string device) {
+    std::string device,
+    int64_t bit_depth) {
   AVFrame* av_frame = unwrap_tensor_to_pointer<AVFrame>(tensor_handle);
-  FramePlanes result =
-      frame_to_planes(*av_frame, StableDevice(device), tensor_handle);
+  FramePlanes result = frame_to_planes(
+      *av_frame, StableDevice(device), bit_depth, tensor_handle);
 
   // Op schema wants a fixed number of planes, so we pad with empty tensors that
   // then get removed at the Python level.
@@ -923,7 +946,13 @@ OpsFrameToPlanesOutput _blocks_frame_to_planes(
       views[3],
       result.pix_fmt,
       result.colorspace,
-      result.color_range);
+      result.color_range,
+      result.bit_depth,
+      result.sample_shift);
+}
+
+int64_t _blocks_packet_decoder_bit_depth(torch::stable::Tensor& decoder) {
+  return unwrap_tensor_to_pointer<PacketDecoder>(decoder)->bit_depth();
 }
 
 // For testing only. We need to implement this operation as a core library
@@ -1490,6 +1519,9 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
       TORCH_BOX(&_blocks_packet_decoder_receive_frame));
   m.impl("_blocks_convert_frame", TORCH_BOX(&_blocks_convert_frame));
   m.impl("_blocks_frame_to_planes", TORCH_BOX(&_blocks_frame_to_planes));
+  m.impl(
+      "_blocks_packet_decoder_bit_depth",
+      TORCH_BOX(&_blocks_packet_decoder_bit_depth));
   m.impl("_test_frame_pts_equality", TORCH_BOX(&_test_frame_pts_equality));
   m.impl(
       "scan_all_streams_to_update_metadata",

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -17,7 +17,14 @@ API_breakdown_claude_plan.md for the design and rationale.
 
 from ._color_converter import ColorConverter
 from ._demuxer import Demuxer
-from ._frame import DecodedFrame, Packet
+from ._frame import DecodedFrame, Packet, RawFrame
 from ._packet_decoder import PacketDecoder
 
-__all__ = ["Demuxer", "PacketDecoder", "ColorConverter", "Packet", "DecodedFrame"]
+__all__ = [
+    "Demuxer",
+    "PacketDecoder",
+    "ColorConverter",
+    "Packet",
+    "DecodedFrame",
+    "RawFrame",
+]

--- a/src/torchcodec/decoders/_blocks/_color_converter.py
+++ b/src/torchcodec/decoders/_blocks/_color_converter.py
@@ -11,7 +11,6 @@ from torchcodec._frame import Frame
 
 from ._frame import DecodedFrame
 
-# TODO_API_BREAKDOWN FEAT support output_dtype?
 # TODO_API_BREAKDOWN FEAT We need to support rotation metadata!!
 # TODO_API_BREAKDOWN FEAT Implement seeking?
 # TODO_API_BREAKDOWN FEAT Implement range-getting (start/end time) for decoding?
@@ -19,12 +18,17 @@ from ._frame import DecodedFrame
 
 class ColorConverter:
     """Color-conversion building block: turns a decoded (YUV)
-    :class:`DecodedFrame` into an RGB :class:`~torchcodec._frame.Frame`
-    (CHW, uint8 -- matching ``VideoDecoder``'s default output).
+    :class:`DecodedFrame` into an RGB :class:`~torchcodec._frame.Frame` (CHW).
 
     Not bound to anything: everything it needs (dims, pixel format, colorspace)
     comes from the frame itself, so one converter can process frames from any
     video. Passive and *not* thread-safe: use one ``ColorConverter`` per thread.
+
+    ``output_dtype`` takes the same values as ``VideoDecoder``'s: ``"uint8"``
+    (default, ``[0, 255]``), ``"float32"`` (``[0, 1]``), or ``"auto"`` (uint8
+    for 8-bit sources, float32 for higher bit depths). Because this block is
+    unbound, ``"auto"`` is resolved per frame rather than once per stream, so
+    feeding it a mix of SDR and HDR frames yields a mix of dtypes.
 
     Note: automatic rotation (from stream side data) is not applied, since this
     block is intentionally stream-agnostic.
@@ -34,8 +38,10 @@ class ColorConverter:
     # TODO_API_BREAKDOWN P1: add checks for coupling between device param of
     # PacketDecoder and ColorConverter. What if one is CPU and the other is
     # CUDA? What if they're different CUDA devices? Maybe we should just error.
-    def __init__(self, device="cpu"):
-        self._handle = _blocks_create_color_converter(device=device)
+    def __init__(self, device="cpu", output_dtype: str = "uint8"):
+        self._handle = _blocks_create_color_converter(
+            device=device, output_dtype=output_dtype
+        )
 
     def convert(self, decoded_frame: DecodedFrame) -> Frame:
         data = _blocks_convert_frame(self._handle, decoded_frame._handle)

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import torch
 
 from torchcodec._core.ops import _blocks_frame_to_planes
@@ -21,6 +23,32 @@ class Packet:
 
     def __init__(self, handle: torch.Tensor):
         self._handle = handle
+
+
+@dataclass
+class RawFrame:
+    """A decoded frame's own samples, as zero-copy views, before any color
+    conversion. Returned by :meth:`DecodedFrame.materialize`.
+
+    ``planes`` holds one strided view per component, in the frame's native
+    order: ``(Y, U, V)`` for the common YUV formats, ``(R, G, B)`` for RGB
+    codecs, ``(Y,)`` for grayscale, plus a trailing alpha view when the format
+    has one. Chroma planes are subsampled (half-resolution for 4:2:0) and the
+    views are usually non-contiguous, which is what avoids the copy.
+
+    Samples of more than 8 bits come back as uint16. ``bit_depth`` says how many
+    of those bits are significant, and ``sample_shift`` how far to right-shift a
+    raw value to recover it: NVDEC's P016 surfaces are msb-aligned so they need
+    a shift, while FFmpeg's planar yuv420p10le is not. Shifting by
+    ``sample_shift`` unconditionally gives the same numbers on CPU and CUDA.
+    """
+
+    planes: tuple[torch.Tensor, ...]
+    pix_fmt: str  # FFmpeg pixel-format name, e.g. "yuv420p"
+    colorspace: str  # e.g. "bt709"
+    color_range: str  # "tv" (limited) or "pc" (full)
+    bit_depth: int
+    sample_shift: int
 
 
 # TODO_API_BREAKDOWN P1: API design - especially the materialize() method but
@@ -45,9 +73,11 @@ class DecodedFrame:
         pts_seconds: float,
         duration_seconds: float,
         device: str = "cpu",
+        bit_depth: int = 8,
     ):
         self._handle = handle
         self._device = device
+        self._bit_depth = bit_depth
         self.pts_seconds = pts_seconds
         self.duration_seconds = duration_seconds
 
@@ -62,11 +92,25 @@ class DecodedFrame:
     # materialize()?
     # What about the planes - should they be 2D (right now they are)? Should we
     # give them names?
-    def materialize(self) -> tuple[tuple[torch.Tensor, ...], str, str, str]:
-        p0, p1, p2, p3, pix_fmt, colorspace, color_range = _blocks_frame_to_planes(
-            self._handle, self._device
-        )
+    def materialize(self) -> RawFrame:
+        (
+            p0,
+            p1,
+            p2,
+            p3,
+            pix_fmt,
+            colorspace,
+            color_range,
+            bit_depth,
+            sample_shift,
+        ) = _blocks_frame_to_planes(self._handle, self._device, self._bit_depth)
         # Absent components come back as empty tensors; real ones are 2D views.
         planes = tuple(p for p in (p0, p1, p2, p3) if p.numel() > 0)
-        # TODO_API_BREAKDOWN P1: yeah this should be a dataclass or something.
-        return planes, pix_fmt, colorspace, color_range
+        return RawFrame(
+            planes=planes,
+            pix_fmt=pix_fmt,
+            colorspace=colorspace,
+            color_range=color_range,
+            bit_depth=bit_depth,
+            sample_shift=sample_shift,
+        )

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from torchcodec._core.ops import (
     _blocks_create_packet_decoder,
+    _blocks_packet_decoder_bit_depth,
     _blocks_packet_decoder_receive_frame,
     _blocks_packet_decoder_send_eof,
     _blocks_packet_decoder_send_packet,
@@ -36,6 +37,12 @@ class PacketDecoder:
         self._handle = _blocks_create_packet_decoder(
             demuxer._handle, num_threads=1, device=device
         )
+        self._bit_depth = _blocks_packet_decoder_bit_depth(self._handle)
+
+    @property
+    def bit_depth(self) -> int:
+        """Significant bits per sample of the source (8, 10, 12...)."""
+        return self._bit_depth
 
     def _drain(self) -> list[DecodedFrame]:
         frames = []
@@ -46,7 +53,13 @@ class PacketDecoder:
             if status != 0:  # EAGAIN (need more packets) or EOF: nothing ready
                 break
             frames.append(
-                DecodedFrame(handle, pts_seconds, duration_seconds, device=device)
+                DecodedFrame(
+                    handle,
+                    pts_seconds,
+                    duration_seconds,
+                    device=device,
+                    bit_depth=self._bit_depth,
+                )
             )
         return frames
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3305,12 +3305,24 @@ def _block_devices():
 # Videos spanning the pixel-format axes materialize() has to handle: 4:2:0 vs
 # 4:4:4 chroma, even vs odd dims (chroma rounds up), and 8- vs 10-/12-bit
 # (uint8 vs uint16 planes). All are YUV, so planes are (Y, U, V).
+# Sources with more than 8 bits per sample.
+_HDR_VIDEOS = (
+    NASA_VIDEO_HDR,
+    TEST_SRC_2_720P_HDR,
+    TEST_SRC_2_12BIT_HDR,
+    TESTSRC2_ODD_WIDTH_VP9_10BIT,
+    TESTSRC2_ODD_HEIGHT_VP9_10BIT,
+    TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9_10BIT,
+)
+
+
+# (video, source bit depth) pairs.
 _MATERIALIZE_VIDEOS = (
-    NASA_VIDEO,  # yuv420p, 8-bit, even dims
-    TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9,  # yuv420p, 8-bit, odd dims
-    TESTSRC2_ODD_HEIGHT_AND_WIDTH_444,  # yuv444p, 8-bit, full-res chroma
-    TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9_10BIT,  # yuv420p10le, 10-bit -> uint16
-    TEST_SRC_2_12BIT_HDR,  # yuv420p12le, 12-bit -> uint16
+    (NASA_VIDEO, 8),  # yuv420p, even dims
+    (TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9, 8),  # yuv420p, odd dims
+    (TESTSRC2_ODD_HEIGHT_AND_WIDTH_444, 8),  # yuv444p, full-res chroma
+    (TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9_10BIT, 10),  # yuv420p10le -> uint16
+    (TEST_SRC_2_12BIT_HDR, 12),  # yuv420p12le -> uint16
 )
 
 
@@ -3518,11 +3530,68 @@ class TestBlocks:
 
         assert got.data.device.type == device
         assert got.data.shape == ref.data.shape
-        torch.testing.assert_close(got.data, ref.data, atol=0, rtol=0)
+        self._assert_matches_video_decoder(got.data, ref.data, video, device)
         torch.testing.assert_close(got.pts_seconds, ref.pts_seconds, atol=0, rtol=0)
         torch.testing.assert_close(
             got.duration_seconds, ref.duration_seconds, atol=0, rtol=0
         )
+
+    @staticmethod
+    def _assert_matches_video_decoder(got, ref, video, device, uint8_output=True):
+        # For HDR + uint8, VideoDecoder decodes into an 8-bit NVDEC surface
+        # while the blocks decode natively, so a few pixels differ (blocks being
+        # the more accurate). Everything else matches exactly.
+        if device == "cuda" and uint8_output and video in _HDR_VIDEOS:
+            assert_tensor_close_on_at_least(got, ref, percentage=99, atol=2)
+        else:
+            torch.testing.assert_close(got, ref, atol=0, rtol=0)
+
+    @pytest.mark.parametrize(
+        "video", (NASA_VIDEO, NASA_VIDEO_HDR, TEST_SRC_2_12BIT_HDR)
+    )
+    @pytest.mark.parametrize(
+        "output_dtype, vd_dtype",
+        (("uint8", torch.uint8), ("float32", torch.float32), ("auto", "auto")),
+    )
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_output_dtype_matches_video_decoder(
+        self, video, output_dtype, vd_dtype, device
+    ):
+        # The blocks pipeline must agree with VideoDecoder for every dtype, on
+        # both devices. See test_matches_video_decoder for why HDR on CUDA needs
+        # a tolerance rather than exact equality.
+        demuxer, decoder, _ = self._make_blocks(video.path, device)
+        converter = ColorConverter(device=device, output_dtype=output_dtype)
+        got = self._to_frame_batch(
+            list(self._convert(converter, self._decode(decoder, self._demux(demuxer))))
+        )
+        ref = VideoDecoder(
+            video.path, device=device, output_dtype=vd_dtype
+        ).get_all_frames()
+
+        assert got.data.dtype == ref.data.dtype
+        assert got.data.shape == ref.data.shape
+        self._assert_matches_video_decoder(
+            got.data, ref.data, video, device, uint8_output=output_dtype == "uint8"
+        )
+
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_output_dtype_auto_is_resolved_per_frame(self, device):
+        # ColorConverter is unbound, so "auto" is decided from each frame rather
+        # than once per stream: the same converter yields uint8 for an 8-bit
+        # video and float32 for a 10-bit one.
+        converter = ColorConverter(device=device, output_dtype="auto")
+        dtypes = []
+        for video in (NASA_VIDEO, NASA_VIDEO_HDR, NASA_VIDEO):
+            frame = next(self._decoded_frames(video.path, device))
+            dtypes.append(converter.convert(frame).data.dtype)
+
+        assert dtypes == [torch.uint8, torch.float32, torch.uint8]
+
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_invalid_output_dtype(self, device):
+        with pytest.raises(RuntimeError, match="Invalid output_dtype"):
+            ColorConverter(device=device, output_dtype="uint16")
 
     @pytest.mark.parametrize("device", _block_devices())
     def test_color_converter_reused_across_videos(self, device):
@@ -3567,16 +3636,17 @@ class TestBlocks:
         frame = next(self._decode(decoder, self._demux(demuxer)))
         return frame, converter
 
-    @pytest.mark.parametrize("video", _MATERIALIZE_VIDEOS)
+    @pytest.mark.parametrize("video, bit_depth", _MATERIALIZE_VIDEOS)
     @pytest.mark.parametrize("device", _block_devices())
-    def test_materialize_structure(self, video, device):
+    def test_materialize_structure(self, video, bit_depth, device):
         # planes shape/dtype/device and the accompanying metadata.
         frame, converter = self._first_frame(video.path, device)
-        planes, pix_fmt, colorspace, color_range = frame.materialize()
+        raw = frame.materialize()
+        planes, pix_fmt = raw.planes, raw.pix_fmt
 
         assert isinstance(pix_fmt, str) and pix_fmt
-        assert colorspace in ("bt709", "bt2020nc", "smpte170m", "unknown")
-        assert color_range in ("tv", "pc", "unknown")  # FFmpeg has only these
+        assert raw.colorspace in ("bt709", "bt2020nc", "smpte170m", "unknown")
+        assert raw.color_range in ("tv", "pc", "unknown")  # FFmpeg has only these
 
         # All planes are 2D views living on the frame's own device.
         # TODO_API_BREAKDOWN P1: Can there be more planes? Should test?
@@ -3585,11 +3655,19 @@ class TestBlocks:
             assert plane.ndim == 2
             assert plane.device.type == frame.device
 
-        # TODO_NOW getting uint16 isn't expected - we never go
-        # through P016 on CUDA, for example. There's a TODO about handling HDr
-        # in general, should figure that out then.
+        # High-bit-depth sources decode natively on both devices, so they yield
+        # uint16 planes everywhere: yuv420p10le on CPU, P016 on CUDA.
         expected_dtype = torch.uint16 if _is_high_depth(pix_fmt) else torch.uint8
         assert all(plane.dtype == expected_dtype for plane in planes)
+
+        # bit_depth is the source's, not the container's: a 10-bit video decoded
+        # into a 16-bit P016 surface still reports 10. sample_shift covers the
+        # difference, so shifting always lands within bit_depth bits.
+        assert raw.bit_depth == bit_depth
+        assert raw.sample_shift >= 0
+        for plane in planes:
+            shifted = plane.to(torch.int32) >> raw.sample_shift
+            assert shifted.max().item() < (1 << raw.bit_depth)
 
         Y, U, V = planes
         height, width = converter.convert(frame).data.shape[1:]
@@ -3612,7 +3690,7 @@ class TestBlocks:
 
         original = converter.convert(frame).data.clone()
 
-        planes, *_ = frame.materialize()
+        planes = frame.materialize().planes
         for value, plane in zip((50, 100, 150), planes):
             plane.fill_(value)  # overwrite Y, U, V with distinct constants
         edited = converter.convert(frame).data
@@ -3631,21 +3709,21 @@ class TestBlocks:
         # Two independent materialize() calls view the same underlying buffer,
         # so a write through one is visible through the other.
         frame, _ = self._first_frame(NASA_VIDEO.path, device)
-        planes_a, *_ = frame.materialize()
-        planes_b, *_ = frame.materialize()
+        planes_a = frame.materialize().planes
+        planes_b = frame.materialize().planes
 
         original = int(planes_a[0][0, 0].item())
         planes_a[0][0, 0] = original ^ 0xFF  # flip first pixel in Y
         assert int(planes_b[0][0, 0].item()) == (original ^ 0xFF)
 
-    @pytest.mark.parametrize("video", _MATERIALIZE_VIDEOS)
+    @pytest.mark.parametrize("video, bit_depth", _MATERIALIZE_VIDEOS)
     @pytest.mark.parametrize("device", _block_devices())
-    def test_materialize_planes_outlive_frame(self, video, device):
+    def test_materialize_planes_outlive_frame(self, video, bit_depth, device):
         # The views keep the frame alive, so they stay valid (readable and
         # writable) after the DecodedFrame they came from is dropped.
         # grep for this test name to see associated comment in the code.
         frame, _ = self._first_frame(video.path, device)
-        planes, *_ = frame.materialize()
+        planes = frame.materialize().planes
         saved = [plane.clone() for plane in planes]
 
         del frame
@@ -3661,7 +3739,7 @@ class TestBlocks:
         # Forcing the chroma planes to neutral (128) yields a gray image
         # (R == G == B). Not testing much, but fun - isn't it?
         frame, converter = self._first_frame(video.path, device)
-        planes, pix_fmt, *_ = frame.materialize()
+        planes = frame.materialize().planes
         assert planes[0].dtype == torch.uint8
 
         _, U, V = planes
@@ -3686,7 +3764,8 @@ class TestBlocks:
         frame, _ = self._first_frame(video.path, "cuda")
         assert frame.device == "cpu"
 
-        planes, pix_fmt, *_ = frame.materialize()
+        raw = frame.materialize()
+        planes, pix_fmt = raw.planes, raw.pix_fmt
         assert pix_fmt != "nv12"
         assert all(plane.device.type == "cpu" for plane in planes)
 


### PR DESCRIPTION
 `main` can already expose a frame's raw YUV samples via DecodedFrame.materialize() (#1608), but the Blocks pipeline
  hardcoded output_dtype=UINT8. On CUDA that made NVDEC decode 10-/12-bit sources straight into an 8-bit NV12 surface, and in general this makes it impossible to support something like `output_dtype` of the `VideoDecoder`.

This PR lets the `PacketDecoder` return frame in their original native pixel format (well, mostly, since stuff still gets converted to NV12 and P016, which contain the same data with slightly different layout).

The `output_dtype `parameter is added to `ColorConverter` and acts consistently with that of the `VideoDecoder`.


We now need something we didn't need before: a `P016 -> uint8` conversion. We didn't need it, because on the VideoDecoder, when the user wants uint8, we tell NVDEC to ouput the decoded data on NV12 surfaces. Here, with the blocks API, we want the PacketDecoder to output native surfaces (hence P016).