### PR TITLE
[DO NOT MERGE] torch.export POC

### DIFF
--- a/export_demo/README.md
+++ b/export_demo/README.md
@@ -1,0 +1,140 @@
+# torch.export → C++ video decoding, without a Python runtime
+
+Working prototype for: **raw video bytes in → decoded frames out**, exported with
+`torch.export`, compiled with AOTInductor, and run from a plain C++ program.
+Metadata is read from the same C++ program by calling the op through the
+dispatcher.
+
+CPU only. Everything below was actually run; the outputs are copy-pasted.
+
+## The pieces
+
+* `export_decoder.py` — traces `bytes + indices -> frames`, checks the exported
+  program against eager, and writes an AOTInductor `.pt2` package.
+* `main.cpp` — a C++ program with no Python: `dlopen`s the torchcodec libraries,
+  queries metadata through the dispatcher, and runs the `.pt2`.
+
+## Run it
+
+```bash
+# 1. Build torchcodec (any normal build works, e.g. pip install -e .)
+
+# 2. Export + AOTInductor-compile
+python export_demo/export_decoder.py test/resources/nasa_13013.mp4 /tmp/decoder.pt2
+
+# 3. Build the C++ program. Nothing here mentions Python.
+TORCH=$(python -c 'import torch, pathlib; print(pathlib.Path(torch.__file__).parent)')
+g++ -std=c++17 -O2 export_demo/main.cpp -o /tmp/decode_video \
+    -I"$TORCH/include" -I"$TORCH/include/torch/csrc/api/include" \
+    -L"$TORCH/lib" -Wl,-rpath,"$TORCH/lib" -ltorch -ltorch_cpu -lc10 -ldl
+
+# 4. Run it
+/tmp/decode_video src/torchcodec test/resources/nasa_13013.mp4 /tmp/decoder.pt2
+```
+
+Output:
+
+```
+metadata: {
+"averageFpsFromHeader": 29.97002997002997,
+"beginStreamSecondsFromContent": 0,
+"bestAudioStreamIndex": 4,
+"bestVideoStreamIndex": 3,
+"bitRate": 412365,
+"codec": "h264",
+"durationSecondsFromHeader": 13.013,
+"endStreamSecondsFromContent": 13.013,
+"height": 270,
+"numFramesFromHeader": 390,
+"width": 480
+}
+frames: [4, 3, 270, 480] unsigned char, sum=16251293
+```
+
+`16251293` is the same sum Python gets for frames `[0, 10, 20, 100]`, both from
+the core ops and from `VideoDecoder.get_frames_at`. Note that the program was
+exported with 3 indices and run with 4: both the encoded-bytes length and the
+number of indices are dynamic.
+
+`LD_DEBUG=libs` on that run loads 98 shared libraries and **zero** matches for
+`libpython`.
+
+## The exported graph
+
+```
+graph():
+    %video_data : placeholder
+    %frame_indices : placeholder
+    %create_video_decoder_from_tensor : torchcodec_ns.create_video_decoder_from_tensor.default(%video_data, num_threads=1)
+    %to : aten.to.dtype(%frame_indices, torch.int64)
+    %get_frames_at_indices : torchcodec_ns.get_frames_at_indices.default(%create_video_decoder_from_tensor, frame_indices=%to)
+    %getitem_3 : getitem(%get_frames_at_indices, 0)
+    ... sym_size / _assert_scalar for the data-dependent H, W, C ...
+    return (getitem_3,)
+```
+
+Two custom-op nodes, connected by the decoder handle. No mutation, no effect
+tokens, no constants baked into the graph. `strict=True` works too, as long as
+`dynamic_shapes` is passed (otherwise the number of indices is specialised).
+
+## What had to change, and why
+
+### 1. A single factory op: `create_video_decoder_from_tensor`
+
+`create_from_tensor` + `add_video_stream` works in eager Python but not in a
+traced graph: `add_video_stream` is a state mutation returning nothing, so
+nothing orders it before the frame reads and nothing keeps it alive. Fusing the
+two into one factory op makes the graph a pure dataflow DAG — the handle *is*
+the dependency edge.
+
+### 2. The frame-reading ops take a plain `Tensor` handle, not `Tensor(a!)`
+
+`(a!)` is what today's ops use to stop `torch.compile` from reordering them. But
+it also tells functionalization it may **clone** the argument, and cloning a
+handle tensor copies the first 64 bytes of the C++ decoder object instead of the
+object. That is undefined behaviour: `run_decompositions()` on an `(a!)` graph
+gives wrong state or segfaults. Neither op on this path needs `(a!)`: random
+frame access is self-contained and the decoder is fully configured by the
+factory op.
+
+Trade-off: without `(a!)` these ops can be CSE'd or DCE'd. Both are harmless
+here (same handle + same indices ⇒ same frames; an unused decode is dead work),
+but it would not be safe for the cursor-based ops (`seek_to_pts`,
+`get_next_frame`), which is why they are left alone. The general fix for those
+is effect tokens (`torch.library._register_effectful_op`), not `(a!)`.
+
+### 3. Fake impls
+
+* `create_from_{file,tensor}` / `_create_from_file_like`: `seek_mode` had no
+  default, and arguments left at their schema default aren't forwarded to the
+  fake, so tracing raised `TypeError` immediately. One-word fix each.
+* `get_frames_at_indices`: was claiming `float32` data and 0-dim `float32`
+  pts/duration; the real op returns `uint8` data and 1-D `float64`. The batch
+  size is now taken from `frame_indices` instead of being data-dependent.
+
+### 4. No pybind11 in the custom-ops library
+
+`custom_ops.cpp` included `<pybind11/pybind11.h>` without using it, which left
+93 undefined `Py*` symbols in `libtorchcodec_custom_opsN.so`. Some of those are
+data symbols, so `dlopen` from a Python-free process would fail. Removing the
+include (and the `pybind11::module` link for that target) brings it to zero.
+`libtorchcodec_pybind_ops` is untouched — that one is genuinely a Python
+extension.
+
+## Known gaps
+
+* **Frame dtype.** The fake hardcodes `uint8`. The real dtype depends on the
+  `output_dtype` the stream was configured with, which the tracer can't see
+  through the opaque handle. Proper fix: thread `output_dtype` into the
+  frame-reading op's schema, or split the op per dtype.
+* **Metadata can't be a graph output.** It's a JSON string; the tracer sees the
+  fake's `""` and constant-folds it. Calling the op through the dispatcher from
+  C++ works (as here) but builds a second, throwaway decoder. If metadata is
+  needed inside the graph, it should be exposed as a numeric tensor
+  (`[num_frames, height, width, ...]`).
+* **`H`/`W`/`C` are data-dependent** (`u0, u1, u2`) so the graph carries
+  `_assert_scalar` guards. AOTInductor handles this for a plain multi-output op,
+  but *not* for one that is mutating or effectful — see the report's §4.6 for
+  the two upstream inductor bugs.
+* `custom_frame_mappings` isn't plumbed through the new factory op.
+* No test coverage yet; `export_decoder.py` is the only thing exercising this.

--- a/export_demo/export_decoder.py
+++ b/export_demo/export_decoder.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Export a video decoding program, then AOTInductor-compile it into a .pt2.
+
+The resulting .pt2 is loadable and runnable from a plain C++ process with no
+Python runtime, see main.cpp.
+
+    python export_demo/export_decoder.py test/resources/nasa_13013.mp4 /tmp/decoder.pt2
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import torch
+from torchcodec._core import (
+    create_video_decoder_from_tensor,
+    get_frames_at_indices,
+    get_json_metadata,
+)
+
+# get_frames_at_indices returns frames whose height and width are only known at
+# runtime, i.e. its output has a data-dependent shape.
+torch._dynamo.config.capture_dynamic_output_shape_ops = True
+
+
+class VideoDecoding(torch.nn.Module):
+    """encoded video bytes + frame indices -> decoded frames."""
+
+    def forward(
+        self, video_data: torch.Tensor, frame_indices: torch.Tensor
+    ) -> torch.Tensor:
+        decoder = create_video_decoder_from_tensor(video_data, num_threads=1)
+        frames, pts_seconds, duration_seconds = get_frames_at_indices(
+            decoder, frame_indices=frame_indices
+        )
+        return frames
+
+
+def main(video_path: str, output_path: str) -> None:
+    video_data = torch.frombuffer(Path(video_path).read_bytes(), dtype=torch.uint8)
+    frame_indices = torch.tensor([0, 10, 20], dtype=torch.int64)
+
+    # Metadata is a JSON string, which can't be an output of an exported program:
+    # the tracer sees the fake impl's return value ("") and would bake that
+    # constant into the graph. It has to be queried out of band - which is
+    # exactly what the C++ side does, by calling the op through the dispatcher.
+    decoder = create_video_decoder_from_tensor(video_data)
+    print("metadata:", json.dumps(json.loads(get_json_metadata(decoder)), indent=2))
+
+    dynamic_shapes = {
+        "video_data": {0: torch.export.Dim.DYNAMIC},
+        "frame_indices": {0: torch.export.Dim.DYNAMIC},
+    }
+    exported = torch.export.export(
+        VideoDecoding(),
+        (video_data, frame_indices),
+        dynamic_shapes=dynamic_shapes,
+        strict=False,
+    )
+    print(exported.graph)
+
+    eager = VideoDecoding()(video_data, frame_indices)
+    from_export = exported.module()(video_data, frame_indices)
+    torch.testing.assert_close(eager, from_export, atol=0, rtol=0)
+    print(f"exported program runs: {tuple(from_export.shape)} {from_export.dtype}")
+
+    torch._inductor.aoti_compile_and_package(exported, package_path=output_path)
+    runner = torch._inductor.aoti_load_package(output_path)
+    from_aoti = runner(video_data, frame_indices)
+    torch.testing.assert_close(eager, from_aoti, atol=0, rtol=0)
+    print(f"AOTInductor package runs: {tuple(from_aoti.shape)} -> {output_path}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/export_demo/main.cpp
+++ b/export_demo/main.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Decode video frames from a plain C++ process: no Python interpreter, no
+// libpython, no torchcodec Python package. Only libtorch + the torchcodec
+// shared libraries + the .pt2 produced by export_decoder.py.
+//
+//   g++ -std=c++17 -O2 main.cpp -o decode_video \
+//       -I"$TORCH/include" -I"$TORCH/include/torch/csrc/api/include" \
+//       -L"$TORCH/lib" -Wl,-rpath,"$TORCH/lib" -ltorch -ltorch_cpu -lc10 -ldl
+//
+//   ./decode_video <torchcodec_lib_dir> <video_file> <decoder.pt2>
+
+#include <dlfcn.h>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <ATen/ATen.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/csrc/inductor/aoti_package/model_package_loader.h>
+
+namespace {
+
+// The ops register themselves into the PyTorch dispatcher from the static
+// initializers of libtorchcodec_custom_opsN, so all a C++ program has to do is
+// load it. libtorchcodec_coreN is loaded first, and RTLD_GLOBAL so that the
+// custom ops library resolves against it.
+void load_torchcodec(const std::string& lib_dir) {
+  for (const char* name :
+       {"libtorchcodec_core7.so", "libtorchcodec_custom_ops7.so"}) {
+    const std::string path = lib_dir + "/" + name;
+    if (dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL) == nullptr) {
+      throw std::runtime_error("dlopen(" + path + ") failed: " + dlerror());
+    }
+  }
+}
+
+// Boxed dispatcher call: every argument, including the ones that have a default
+// in the schema, is pushed onto the stack in declaration order.
+c10::IValue call_op(const char* name, std::vector<c10::IValue> stack) {
+  const auto op = c10::Dispatcher::singleton().findSchemaOrThrow(name, "");
+  op.callBoxed(&stack);
+  TORCH_CHECK(stack.size() == 1, "expected a single return value from ", name);
+  return std::move(stack[0]);
+}
+
+at::Tensor read_file(const std::string& path) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  TORCH_CHECK(file, "could not open ", path);
+  const std::streamsize size = file.tellg();
+  file.seekg(0, std::ios::beg);
+  at::Tensor data = at::empty({size}, at::kByte);
+  TORCH_CHECK(
+      file.read(reinterpret_cast<char*>(data.data_ptr<uint8_t>()), size),
+      "could not read ",
+      path);
+  return data;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  if (argc != 4) {
+    std::cerr << "usage: " << argv[0]
+              << " <torchcodec_lib_dir> <video_file> <decoder.pt2>\n";
+    return 1;
+  }
+  const std::string lib_dir = argv[1];
+  const std::string video_file = argv[2];
+  const std::string package_path = argv[3];
+
+  load_torchcodec(lib_dir);
+
+  const at::Tensor video_data = read_file(video_file);
+  const at::Tensor frame_indices =
+      at::tensor({0, 10, 20, 100}, at::TensorOptions().dtype(at::kLong));
+
+  // Metadata. This can't come out of the exported program: it's a JSON string,
+  // and the tracer would constant-fold the fake impl's empty return value into
+  // the graph. So we call the op directly through the dispatcher instead. Note
+  // that this is a *second*, throwaway decoder, used only for its metadata; the
+  // one that decodes frames lives inside the exported program.
+  const at::Tensor decoder =
+      call_op(
+          "torchcodec_ns::create_video_decoder_from_tensor",
+          {video_data,
+           /*seek_mode=*/c10::IValue(),
+           /*num_threads=*/c10::IValue(),
+           /*dimension_order=*/c10::IValue(),
+           /*stream_index=*/c10::IValue(),
+           /*device=*/std::string("cpu"),
+           /*device_variant=*/std::string("default"),
+           /*transform_specs=*/std::string(""),
+           /*output_dtype=*/std::string("uint8")})
+          .toTensor();
+  const std::string metadata =
+      call_op("torchcodec_ns::get_json_metadata", {decoder}).toStringRef();
+  std::cout << "metadata: " << metadata << "\n";
+
+  // Decoding, by running the exported + AOTInductor-compiled program.
+  torch::inductor::AOTIModelPackageLoader loader(package_path);
+  const std::vector<at::Tensor> outputs =
+      loader.run({video_data, frame_indices});
+
+  const at::Tensor& frames = outputs.at(0);
+  std::cout << "frames: " << frames.sizes() << " " << frames.dtype()
+            << ", sum=" << frames.sum().item<int64_t>() << "\n";
+
+  return 0;
+}

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -365,14 +365,11 @@ function(make_torchcodec_libraries
     set(custom_ops_sources
         ${TORCHCODEC_CUSTOM_OPS_SOURCES}
     )
+    # No pybind11 / Python dependency here: this library is loaded by
+    # Python-free C++ runtimes (see the torch.export deployment path), and
+    # referencing the Python C API would make dlopen fail without libpython.
     set(custom_ops_dependencies
         ${core_library_name}
-        pybind11::module # Links Python correctly per-platform (nothing extra on
-                         # Linux, dynamic-lookup on Mac, import lib on Windows).
-                         # Using ${Python3_LIBRARIES} instead adds a DT_NEEDED on
-                         # a shared libpython (e.g. free-threaded builds ship
-                         # libpython3.XXt.so), which auditwheel then wrongly
-                         # bundles into the wheel.
     )
     make_torchcodec_sublibrary(
         "${custom_ops_library_name}"

--- a/src/torchcodec/_core/__init__.py
+++ b/src/torchcodec/_core/__init__.py
@@ -19,6 +19,7 @@ from .ops import (
     _test_frame_pts_equality,
     core_library_path,
     create_streaming_encoder,
+    create_video_decoder_from_tensor,
     create_wav_decoder_from_file,
     ffmpeg_major_version,
     get_ffmpeg_library_versions,

--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -14,6 +14,7 @@ FFMPEG_OP_NAMES = frozenset(
     {
         "create_from_file",
         "create_from_tensor",
+        "create_video_decoder_from_tensor",
         "_create_from_file_like",
         "_add_video_stream_raw",
         "_add_video_stream",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -34,6 +34,11 @@ create_from_tensor = torch._dynamo.disallow_in_graph(
 _create_from_file_like = torch._dynamo.disallow_in_graph(
     torch.ops.torchcodec_ns._create_from_file_like.default
 )
+# Not disallowed in graph: this one is meant to be traced, it's the entry point
+# of the torch.export path.
+create_video_decoder_from_tensor = (
+    torch.ops.torchcodec_ns.create_video_decoder_from_tensor.default
+)
 _add_video_stream_raw = torch.ops.torchcodec_ns.add_video_stream.default
 _add_video_stream = torch.ops.torchcodec_ns._add_video_stream.default
 
@@ -254,23 +259,46 @@ def get_frames_by_pts(
 # ==============================
 # Abstract impl for the operators. Needed by torch.compile.
 # ==============================
+# Note: the `= None` defaults matter. Arguments that are left at their schema
+# default aren't passed down to the fake impl, so a fake whose parameters are
+# all required raises TypeError as soon as the op is traced.
 @register_fake("torchcodec_ns::create_from_file")
-def create_from_file_abstract(filename: str, seek_mode: str | None) -> torch.Tensor:
+def create_from_file_abstract(
+    filename: str, seek_mode: str | None = None
+) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 
 
 @register_fake("torchcodec_ns::_create_from_file_like")
 def _create_from_file_like_abstract(
-    file_like: int, seek_mode: str | None
+    file_like: int, seek_mode: str | None = None
 ) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 
 
 @register_fake("torchcodec_ns::create_from_tensor")
 def create_from_tensor_abstract(
-    video_tensor: torch.Tensor, seek_mode: str | None
+    video_tensor: torch.Tensor, seek_mode: str | None = None
 ) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
+
+
+@register_fake("torchcodec_ns::create_video_decoder_from_tensor")
+def create_video_decoder_from_tensor_abstract(
+    video_data: torch.Tensor,
+    *,
+    seek_mode: str | None = None,
+    num_threads: int | None = None,
+    dimension_order: str | None = None,
+    stream_index: int | None = None,
+    device: str = "cpu",
+    device_variant: str = "default",
+    transform_specs: str = "",
+    output_dtype: str = "uint8",
+) -> torch.Tensor:
+    # The real handle tensor views the first sizeof(SingleStreamDecoder*)
+    # int64s of the decoder object, i.e. it has shape [8].
+    return torch.empty([8], dtype=torch.long)
 
 
 @register_fake("torchcodec_ns::_add_video_stream")
@@ -380,13 +408,18 @@ def get_frame_at_index_abstract(
 
 @register_fake("torchcodec_ns::get_frames_at_indices")
 def get_frames_at_indices_abstract(
-    decoder: torch.Tensor, *, frame_indices: torch.Tensor | list[int]
+    decoder: torch.Tensor, *, frame_indices: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    image_size = [get_ctx().new_dynamic_size() for _ in range(4)]
+    num_frames = frame_indices.shape[0]
+    # The frame geometry isn't knowable from the decoder handle, which is opaque
+    # to the tracer, so those dims are data-dependent. The output dtype is
+    # assumed to be the default uint8: it actually depends on the output_dtype
+    # the stream was configured with, which the tracer can't see either.
+    frame_shape = [get_ctx().new_dynamic_size() for _ in range(3)]
     return (
-        torch.empty(image_size),
-        torch.empty([], dtype=torch.float),
-        torch.empty([], dtype=torch.float),
+        torch.empty([num_frames, *frame_shape], dtype=torch.uint8),
+        torch.empty([num_frames], dtype=torch.float64),
+        torch.empty([num_frames], dtype=torch.float64),
     )
 
 

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -4,13 +4,12 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
-// fmt and pybind11 headers from torch error out if TORCH_TARGET_VERSION is
-// defined, so we temporarily undefine it.
+// The fmt headers from torch error out if TORCH_TARGET_VERSION is defined, so
+// we temporarily undefine it.
 // See https://github.com/pytorch/pytorch/pull/174372 for context
 #pragma push_macro("TORCH_TARGET_VERSION")
 #undef TORCH_TARGET_VERSION
 #include <fmt/format.h>
-#include <pybind11/pybind11.h>
 #pragma pop_macro("TORCH_TARGET_VERSION")
 #include <cstdint>
 #include <string>
@@ -45,10 +44,21 @@ namespace facebook::torchcodec {
 // calls to these functions. For more detail, see:
 //   https://github.com/pytorch/pytorch/tree/main/aten/src/ATen/native#readme
 //
+// Exception: the ops on the torch.export path (create_video_decoder_from_tensor
+// and get_frames_at_indices) take a plain `Tensor` decoder. `(a!)` tells
+// functionalization it may clone the argument, and cloning a handle tensor
+// copies the first bytes of the C++ decoder object rather than the object
+// itself, which is undefined behaviour. Those ops don't need `(a!)` for
+// ordering either: random frame access is self-contained, and the decoder is
+// fully configured by the single factory op that produced the handle, so the
+// handle's data dependency is enough to order the graph.
+//
 STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def("create_from_file(str filename, str? seek_mode=None) -> Tensor");
   m.def(
       "create_from_tensor(Tensor video_tensor, str? seek_mode=None) -> Tensor");
+  m.def(
+      "create_video_decoder_from_tensor(Tensor video_data, *, str? seek_mode=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"default\", str transform_specs=\"\", str output_dtype=\"uint8\") -> Tensor");
   m.def(
       "_create_from_file_like(int file_like_context, str? seek_mode=None) -> Tensor");
   m.def(
@@ -64,7 +74,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def(
       "get_frame_at_index(Tensor(a!) decoder, *, int frame_index) -> (Tensor, Tensor, Tensor)");
   m.def(
-      "get_frames_at_indices(Tensor(a!) decoder, *, Tensor frame_indices) -> (Tensor, Tensor, Tensor)");
+      "get_frames_at_indices(Tensor decoder, *, Tensor frame_indices) -> (Tensor, Tensor, Tensor)");
   m.def(
       "get_frames_in_range(Tensor(a!) decoder, *, int start, int stop, int? step=None) -> (Tensor, Tensor, Tensor)");
   m.def(
@@ -664,6 +674,43 @@ void add_video_stream(
       std::move(custom_frame_mappings_keyframe_indices),
       /*color_conversion_library=*/std::nullopt,
       std::move(output_dtype));
+}
+
+// Create a decoder from the raw bytes of a video *and* add its video stream, in
+// a single call.
+//
+// This exists for torch.export. Doing the two steps separately works in eager
+// Python, but in a traced graph add_video_stream is a state mutation with no
+// return value: there is no data dependency keeping it ordered before the
+// frame-reading ops, and nothing keeping it in the graph at all. Fusing the two
+// makes the exported program a pure dataflow DAG - bytes -> handle -> frames -
+// with no mutable arguments and no side effects for the tracer to model.
+torch::stable::Tensor create_video_decoder_from_tensor(
+    const torch::stable::Tensor& video_data,
+    std::optional<std::string> seek_mode = std::nullopt,
+    std::optional<int64_t> num_threads = std::nullopt,
+    std::optional<std::string> dimension_order = std::nullopt,
+    std::optional<int64_t> stream_index = std::nullopt,
+    std::string device = "cpu",
+    std::string device_variant = "default",
+    std::string transform_specs = "",
+    std::string output_dtype = "uint8") {
+  torch::stable::Tensor decoder =
+      create_from_tensor(video_data, std::move(seek_mode));
+  _add_video_stream(
+      decoder,
+      num_threads,
+      std::move(dimension_order),
+      stream_index,
+      std::move(device),
+      std::move(device_variant),
+      std::move(transform_specs),
+      /*custom_frame_mappings_pts=*/std::nullopt,
+      /*custom_frame_mappings_duration=*/std::nullopt,
+      /*custom_frame_mappings_keyframe_indices=*/std::nullopt,
+      /*color_conversion_library=*/std::nullopt,
+      std::move(output_dtype));
+  return decoder;
 }
 
 void add_audio_stream(
@@ -1410,6 +1457,9 @@ int64_t _get_log_level() {
 STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, BackendSelect, m) {
   m.impl("create_from_file", TORCH_BOX(&create_from_file));
   m.impl("create_from_tensor", TORCH_BOX(&create_from_tensor));
+  m.impl(
+      "create_video_decoder_from_tensor",
+      TORCH_BOX(&create_video_decoder_from_tensor));
   m.impl("_create_from_file_like", TORCH_BOX(&_create_from_file_like));
   m.impl("_blocks_create_demuxer", TORCH_BOX(&_blocks_create_demuxer));
   m.impl(


### PR DESCRIPTION
Fully vibe-coded, mainly just to assess the blockers / feasibility / possible feature support.

TL;DR the core ops should be exportable with a little work, but there are stuff I don't understand still:

- The changes of `tensor(a!)` into just `tensor`. I don't undestand this claim (what it means, and its validity):

> Neither op on this path needs `(a!)`: random frame access is self-contained and the decoder is fully configured by the factory op.

- The need for a single factory op: `create_video_decoder_from_tensor` as `create_from_tensor` + `add_video_stream`

---

If we ever expose torch.export support, this should be a new public namespace and with potentially slightly different ops API. This should not be in `_core` which is private and meant to stay private.