### PR TITLE
Audio resampler postroll fix

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -1224,6 +1224,7 @@ AudioFramesOutput SingleStreamDecoder::get_frames_played_in_range_audio(
       (codec_descriptor->props & AV_CODEC_PROP_LOSSLESS) != 0;
 
   double target_preroll_seconds;
+  double target_postroll_seconds = 0.0;
   if (is_lossless) {
     target_preroll_seconds = 0.0;
   } else if (frame_size > 0) {
@@ -1256,6 +1257,8 @@ AudioFramesOutput SingleStreamDecoder::get_frames_played_in_range_audio(
     target_preroll_seconds = std::max(
         target_preroll_seconds,
         (alignment - 1 + 2 * filter_length) / src_sample_rate);
+
+    target_postroll_seconds = 2 * filter_length / src_sample_rate;
   }
   auto target_seek_pts = seconds_to_closest_pts(
       start_seconds - target_preroll_seconds, stream_info.time_base);
@@ -1306,15 +1309,21 @@ AudioFramesOutput SingleStreamDecoder::get_frames_played_in_range_audio(
   // When resampling, we must send the prerolled frames through the resampler!
   auto output_start_pts =
       is_resampling ? std::min(start_pts, target_seek_pts) : start_pts;
+  // See [Resampler Postroll]. Note that stop_pts, not this, is what decides
+  // whether we've decoded the whole requested range.
+  auto output_stop_pts = (stop_pts == INT64_MAX) ? stop_pts
+                                                 : stop_pts +
+          seconds_to_closest_pts(target_postroll_seconds,
+                                 stream_info.time_base);
 
   auto finished = false;
   while (!finished) {
     try {
       UniqueAVFrame av_frame = decode_av_frame(
-          [output_start_pts, stop_pts](const AVFrame& av_frame) {
+          [output_start_pts, output_stop_pts](const AVFrame& av_frame) {
             return output_start_pts <
                 get_pts_or_dts(av_frame) + get_duration(av_frame) &&
-                stop_pts > get_pts_or_dts(av_frame);
+                output_stop_pts > get_pts_or_dts(av_frame);
           });
       auto frame_output = convert_av_frame_to_frame_output(*av_frame);
       if (!first_frame_pts_seconds.has_value()) {
@@ -1331,8 +1340,8 @@ AudioFramesOutput SingleStreamDecoder::get_frames_played_in_range_audio(
     // stopSeconds, which isn't what we want!
     auto last_decoded_av_frame_end =
         last_decoded_av_frame_pts_ + last_decoded_av_frame_duration_;
-    finished |= (last_decoded_av_frame_pts_) <= stop_pts &&
-        (stop_pts <= last_decoded_av_frame_end);
+    finished |= (last_decoded_av_frame_pts_) <= output_stop_pts &&
+        (output_stop_pts <= last_decoded_av_frame_end);
   }
 
   auto last_samples = device_interface_->maybe_flush_audio_buffers();

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -1309,7 +1309,8 @@ AudioFramesOutput SingleStreamDecoder::get_frames_played_in_range_audio(
   // When resampling, we must send the prerolled frames through the resampler!
   auto output_start_pts =
       is_resampling ? std::min(start_pts, target_seek_pts) : start_pts;
-  // See [Resampler Postroll]. Note that stop_pts, not this, is what decides
+  // See [Audio pre-roll and post-roll]. Note that stop_pts, not
+  // this, is what decides
   // whether we've decoded the whole requested range.
   auto output_stop_pts = (stop_pts == INT64_MAX) ? stop_pts
                                                  : stop_pts +

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -1306,12 +1306,10 @@ AudioFramesOutput SingleStreamDecoder::get_frames_played_in_range_audio(
       ? seconds_to_closest_pts(*stop_seconds_optional, stream_info.time_base)
       : INT64_MAX;
 
-  // When resampling, we must send the prerolled frames through the resampler!
+  // When resampling, we must send the prerolled and postrolled frames through
+  // the resampler!
   auto output_start_pts =
       is_resampling ? std::min(start_pts, target_seek_pts) : start_pts;
-  // See [Audio pre-roll and post-roll]. Note that stop_pts, not
-  // this, is what decides
-  // whether we've decoded the whole requested range.
   auto output_stop_pts = (stop_pts == INT64_MAX) ? stop_pts
                                                  : stop_pts +
           seconds_to_closest_pts(target_postroll_seconds,
@@ -1335,10 +1333,13 @@ AudioFramesOutput SingleStreamDecoder::get_frames_played_in_range_audio(
       finished = true;
     }
 
-    // If stopSeconds is in [begin, end] of the last decoded frame, we should
-    // stop decoding more frames. Note that if we were to use [begin, end),
-    // which may seem more natural, then we would decode the frame starting at
-    // stopSeconds, which isn't what we want!
+    // We're done once output_stop_pts falls within the last decoded frame,
+    // bounds
+    // included. Excluding the upper bound would look more natural, but when
+    // output_stop_pts lands exactly on a frame boundary we'd keep going: the
+    // frame starting there is rejected by the pts filter above, as is every
+    // frame after it, so we'd decode to EOF for the same output.
+
     auto last_decoded_av_frame_end =
         last_decoded_av_frame_pts_ + last_decoded_av_frame_duration_;
     finished |= (last_decoded_av_frame_pts_) <= output_stop_pts &&

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3143,6 +3143,29 @@ class TestAudioDecoder:
         else:
             torch.testing.assert_close(chunks, full.data, atol=0, rtol=0)
 
+    @pytest.mark.parametrize("out_sample_rate", (8_000, 16_000))
+    @pytest.mark.parametrize("stop_seconds", (1.45, 1.91, 2.1))
+    def test_resample_range_end_matches_full(self, out_sample_rate, stop_seconds):
+        # The last samples of a range must match a start-to-finish decode too.
+        # swresample holds samples back until it gets the input that follows
+        # them, and whatever is still held back when the range ends is converted
+        # against silence instead. These stop_seconds make decoding stop a
+        # fraction of a millisecond after them, which is not enough to push
+        # those samples out of the requested range on its own.
+        # See [Resampler Postroll].
+        asset = SINE_MONO_S32_44100
+        full = (
+            AudioDecoder(asset.path, sample_rate=out_sample_rate).get_all_samples().data
+        )
+
+        decoder = AudioDecoder(asset.path, sample_rate=out_sample_rate)
+        samples = decoder.get_samples_played_in_range(1.0, stop_seconds).data
+
+        start = round(1.0 * out_sample_rate)
+        torch.testing.assert_close(
+            samples, full[:, start : start + samples.shape[1]], atol=0, rtol=0
+        )
+
     def test_decode_s16_ffmpeg4(self):
         # Non-regression test for https://github.com/pytorch/torchcodec/issues/843
         # Ensures that decoding s16 on FFmpeg4 handles

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3152,7 +3152,7 @@ class TestAudioDecoder:
         # against silence instead. These stop_seconds make decoding stop a
         # fraction of a millisecond after them, which is not enough to push
         # those samples out of the requested range on its own.
-        # See [Resampler Postroll].
+        # See [Audio pre-roll and post-roll].
         asset = SINE_MONO_S32_44100
         full = (
             AudioDecoder(asset.path, sample_rate=out_sample_rate).get_all_samples().data

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3145,14 +3145,13 @@ class TestAudioDecoder:
 
     @pytest.mark.parametrize("out_sample_rate", (8_000, 16_000))
     @pytest.mark.parametrize("stop_seconds", (1.45, 1.91, 2.1))
-    def test_resample_range_end_matches_full(self, out_sample_rate, stop_seconds):
-        # The last samples of a range must match a start-to-finish decode too.
-        # swresample holds samples back until it gets the input that follows
-        # them, and whatever is still held back when the range ends is converted
-        # against silence instead. These stop_seconds make decoding stop a
-        # fraction of a millisecond after them, which is not enough to push
-        # those samples out of the requested range on its own.
-        # See [Audio pre-roll and post-roll].
+    def test_resample_chunked_matches_full_postroll(
+        self, out_sample_rate, stop_seconds
+    ):
+        # Test for resampling post-roll. Basically a subset of
+        # test_resample_chunked_matches_full but with a focus on postroll:
+        # stop_seconds values are chosen such that they actually fail on main
+        # and exercise the post-roll fix.
         asset = SINE_MONO_S32_44100
         full = (
             AudioDecoder(asset.path, sample_rate=out_sample_rate).get_all_samples().data


### PR DESCRIPTION
Direct follow-up to https://github.com/meta-pytorch/torchcodec/pull/1614 which focused on pre-roll, this one is about post-roll.


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>