### PR TITLE
AudioDecoder: fix chunk decoding when split is exactly at half a sample boundary

### DIFF
--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -6,6 +6,7 @@
 
 
 import io
+import math
 from pathlib import Path
 
 import torch
@@ -144,8 +145,17 @@ class AudioDecoder:
         # TODO: metadata's sample_rate should probably not be Optional
         assert sample_rate is not None  # mypy.
 
+        def offset_of(seconds: float) -> int:
+            # Ties go up. round() sends them to the nearest *even* sample
+            # instead, which isn't stable from one call to the next: each call
+            # measures its boundaries from its own first_pts, and how far that
+            # is from the boundary decides which of the two samples is the even
+            # one. Consecutive ranges would then disagree on who owns the sample
+            # on their common boundary, and return it twice or not at all.
+            return math.floor((seconds - first_pts) * sample_rate + 0.5)
+
         if first_pts < start_seconds:
-            offset_beginning = round((start_seconds - first_pts) * sample_rate)
+            offset_beginning = offset_of(start_seconds)
             output_pts_seconds = start_seconds
         else:
             # In normal cases we'll have first_pts <= start_pts, but in some
@@ -155,9 +165,8 @@ class AudioDecoder:
             output_pts_seconds = first_pts
 
         num_samples = frames.shape[1]
-        last_pts = first_pts + num_samples / sample_rate
-        if stop_seconds is not None and stop_seconds < last_pts:
-            offset_end = num_samples - round((last_pts - stop_seconds) * sample_rate)
+        if stop_seconds is not None:
+            offset_end = min(num_samples, offset_of(stop_seconds))
         else:
             offset_end = num_samples
 

--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -149,8 +149,10 @@ class AudioDecoder:
             # This is morally equivalent to round((seconds - first_pts) *
             # sample_rate), but round() is not stable across calls for a fixed
             # value of `seconds` because it rounds to the nearest even interger,
-            # so where it rounds is dependent on the value of first_pts.
+            # so where it rounds is dependent on the value of `first_pts`.
             # This formulation forces ties to always round up.
+            # The non-regression test for this is
+            # test_chunk_boundary_half_sample
             return math.floor((seconds - first_pts) * sample_rate + 0.5)
 
         if first_pts < start_seconds:

--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -146,12 +146,11 @@ class AudioDecoder:
         assert sample_rate is not None  # mypy.
 
         def offset_of(seconds: float) -> int:
-            # Ties go up. round() sends them to the nearest *even* sample
-            # instead, which isn't stable from one call to the next: each call
-            # measures its boundaries from its own first_pts, and how far that
-            # is from the boundary decides which of the two samples is the even
-            # one. Consecutive ranges would then disagree on who owns the sample
-            # on their common boundary, and return it twice or not at all.
+            # This is morally equivalent to round((seconds - first_pts) *
+            # sample_rate), but round() is not stable across calls for a fixed
+            # value of `seconds` because it rounds to the nearest even interger,
+            # so where it rounds is dependent on the value of first_pts.
+            # This formulation forces ties to always round up.
             return math.floor((seconds - first_pts) * sample_rate + 0.5)
 
         if first_pts < start_seconds:

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3143,27 +3143,6 @@ class TestAudioDecoder:
         else:
             torch.testing.assert_close(chunks, full.data, atol=0, rtol=0)
 
-    @pytest.mark.parametrize("asset", (SINE_MONO_S32_44100, SINE_MONO_U8))
-    def test_resample_chunk_boundary_tie(self, asset):
-        # 0.7s at 16_001Hz puts the boundary between two chunks exactly half a
-        # sample off: 3.5s is sample 56003.5. Both chunks have to round that to
-        # the same sample, or the sample on the boundary ends up in both of
-        # them, or in neither.
-        out_sample_rate, increment = 16_001, 0.7
-        full = AudioDecoder(asset.path, sample_rate=out_sample_rate).get_all_samples()
-        end_seconds = full.pts_seconds + full.data.shape[1] / out_sample_rate
-
-        decoder = AudioDecoder(asset.path, sample_rate=out_sample_rate)
-        chunks = [
-            decoder.get_samples_played_in_range(
-                full.pts_seconds + i * increment,
-                full.pts_seconds + i * increment + increment,
-            ).data
-            for i in range(math.ceil((end_seconds - full.pts_seconds) / increment))
-        ]
-
-        torch.testing.assert_close(torch.cat(chunks, dim=1), full.data, atol=0, rtol=0)
-
     @pytest.mark.parametrize("out_sample_rate", (8_000, 16_000))
     @pytest.mark.parametrize("stop_seconds", (1.45, 1.91, 2.1))
     def test_resample_chunked_matches_full_postroll(
@@ -3185,6 +3164,26 @@ class TestAudioDecoder:
         torch.testing.assert_close(
             samples, full[:, start : start + samples.shape[1]], atol=0, rtol=0
         )
+
+    @pytest.mark.parametrize("boundary_sample", (6_000, 20_000, 30_000))
+    def test_chunk_boundary_half_sample(self, boundary_sample):
+        # Reading the stream in two chunks, splitting right in the middle of a
+        # sample. That sample must be returned by exactly one of the two chunks,
+        # and the two chunks must independently agree on which one.
+        # This is ensured by a stable rounding (see offset_of()).
+        asset = SINE_MONO_S32
+        boundary = (boundary_sample + 0.5) / asset.sample_rate
+
+        full = AudioDecoder(asset.path).get_all_samples()
+        end_seconds = full.pts_seconds + full.data.shape[1] / asset.sample_rate
+
+        decoder = AudioDecoder(asset.path)
+        chunks = [
+            decoder.get_samples_played_in_range(full.pts_seconds, boundary).data,
+            decoder.get_samples_played_in_range(boundary, end_seconds).data,
+        ]
+
+        torch.testing.assert_close(torch.cat(chunks, dim=1), full.data, atol=0, rtol=0)
 
     def test_decode_s16_ffmpeg4(self):
         # Non-regression test for https://github.com/pytorch/torchcodec/issues/843

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3143,6 +3143,27 @@ class TestAudioDecoder:
         else:
             torch.testing.assert_close(chunks, full.data, atol=0, rtol=0)
 
+    @pytest.mark.parametrize("asset", (SINE_MONO_S32_44100, SINE_MONO_U8))
+    def test_resample_chunk_boundary_tie(self, asset):
+        # 0.7s at 16_001Hz puts the boundary between two chunks exactly half a
+        # sample off: 3.5s is sample 56003.5. Both chunks have to round that to
+        # the same sample, or the sample on the boundary ends up in both of
+        # them, or in neither.
+        out_sample_rate, increment = 16_001, 0.7
+        full = AudioDecoder(asset.path, sample_rate=out_sample_rate).get_all_samples()
+        end_seconds = full.pts_seconds + full.data.shape[1] / out_sample_rate
+
+        decoder = AudioDecoder(asset.path, sample_rate=out_sample_rate)
+        chunks = [
+            decoder.get_samples_played_in_range(
+                full.pts_seconds + i * increment,
+                full.pts_seconds + i * increment + increment,
+            ).data
+            for i in range(math.ceil((end_seconds - full.pts_seconds) / increment))
+        ]
+
+        torch.testing.assert_close(torch.cat(chunks, dim=1), full.data, atol=0, rtol=0)
+
     @pytest.mark.parametrize("out_sample_rate", (8_000, 16_000))
     @pytest.mark.parametrize("stop_seconds", (1.45, 1.91, 2.1))
     def test_resample_chunked_matches_full_postroll(


### PR DESCRIPTION
See non-regression test and comment. The fix is to make our `round()` mechanism stable across calls.

With the previous PRs below in this stack, this should correctly fix https://github.com/meta-pytorch/torchcodec/issues/1601

Closes https://github.com/meta-pytorch/torchcodec/issues/1601


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>