### PR TITLE
Add CUDA jpeg decoding to benchmark

### DIFF
--- a/benchmarks/decoders/benchmark_image_decoders.py
+++ b/benchmarks/decoders/benchmark_image_decoders.py
@@ -118,6 +118,15 @@ def _median_ms(times: Tensor) -> float:
     return (times * 1e-6).median().item()
 
 
+def cuda_synced(fn):
+    # Wrap fn so device-side work completes inside the timed region.
+    def g():
+        fn()
+        torch.cuda.synchronize()
+
+    return g
+
+
 # ---------------------------------------------------------------------------
 # Test image generation
 # ---------------------------------------------------------------------------
@@ -177,17 +186,51 @@ def encode_images(image: Image.Image, resolutions, out_dir: Path) -> dict:
 # uint8 byte tensor (from_file=False, timing pure decode) or straight from a
 # file path (from_file=True, timing decode + I/O).
 # ---------------------------------------------------------------------------
-def decode_torchcodec(fmt: str, path: Path, data: Tensor, from_file: bool) -> Tensor:
-    return _TC_DECODERS[fmt](path if from_file else data, mode="RGB")
+def decode_torchcodec(
+    fmt: str, path: Path, data: Tensor, from_file: bool, device: str = "cpu"
+) -> Tensor:
+    source = path if from_file else data
+    if device == "cpu":
+        return _TC_DECODERS[fmt](source, mode="RGB")
+    return decode_jpeg(source, mode="RGB", device=device)
 
 
-def decode_torchvision(fmt: str, path: Path, data: Tensor, from_file: bool) -> Tensor:
-    return _TV_DECODERS[fmt](tv_read_file(str(path)) if from_file else data)
+def decode_torchvision(
+    fmt: str, path: Path, data: Tensor, from_file: bool, device: str = "cpu"
+) -> Tensor:
+    source = tv_read_file(str(path)) if from_file else data
+    if device == "cpu":
+        return _TV_DECODERS[fmt](source)
+    return tv_decode_jpeg(source, "RGB", device=device)
 
 
 def decode_pil(path: Path, raw: bytes, from_file: bool) -> Tensor:
     img = Image.open(path if from_file else io.BytesIO(raw)).convert("RGB")
     return pil_to_tensor(img)
+
+
+def make_batch_decode_fn(
+    backend: str,
+    path: Path,
+    data: Tensor,
+    from_file: bool,
+    batch_size: int,
+    device: str,
+):
+    """Decode a batch of identical JPEGs in a single call. Both libraries return
+    a list of decoded device tensors. torchvision only takes byte tensors, so
+    with --from-file we read the files inside the timed region, which is what
+    torchcodec does internally when handed paths."""
+    if backend == "torchcodec":
+        sources = [path if from_file else data] * batch_size
+        return lambda: decode_jpeg(sources, mode="RGB", device=device)
+
+    if from_file:
+        return lambda: tv_decode_jpeg(
+            [tv_read_file(str(path)) for _ in range(batch_size)], "RGB", device=device
+        )
+    sources = [data] * batch_size
+    return lambda: tv_decode_jpeg(sources, "RGB", device=device)
 
 
 def decode_ffmpeg(path: Path, data: Tensor, from_file: bool) -> Tensor:
@@ -209,6 +252,19 @@ def main():
         "--resolutions", nargs="+", default=list(RESOLUTIONS), choices=list(RESOLUTIONS)
     )
     parser.add_argument("--num-exp", type=int, default=DEFAULT_NUM_EXP)
+    parser.add_argument(
+        "--devices",
+        nargs="+",
+        default=["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"],
+        choices=["cpu", "cuda"],
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        nargs="+",
+        type=int,
+        default=[1, 16, 64],
+        help="batch sizes for the CUDA batch-decode comparison",
+    )
     parser.add_argument(
         "--image",
         type=Path,
@@ -234,9 +290,6 @@ def main():
     print(
         f"torch.get_num_threads()={torch.get_num_threads()}, OMP_NUM_THREADS={os.environ.get('OMP_NUM_THREADS')}"
     )
-    print(
-        "Note: libavif/dav1d internal threading is not exposed by decode_avif (library default)."
-    )
     print(f"Source: {'file path' if args.from_file else 'in-memory bytes'}")
 
     image = load_source_image(args.image)
@@ -244,42 +297,55 @@ def main():
     paths = encode_images(image, args.resolutions, Path(tmp.name))
 
     backends = ["torchcodec", "PIL", "torchvision", "FFmpeg"]
-    rows = []  # (fmt, res, sizes_kb, {backend: median_ms})
+    rows = []  # (fmt, device, res, sizes_kb, {backend: median_ms})
 
-    for fmt in _EXT:
-        for res_label in args.resolutions:
-            path = paths[(fmt, res_label)]
-            raw = path.read_bytes()
-            data = torch.frombuffer(bytearray(raw), dtype=torch.uint8)
-            size_kb = len(raw) / 1024.0
-            results = {}
-            for backend in backends:
-                # torchvision has no avif/heic decoder; leave those cells blank.
-                if backend == "torchvision" and fmt not in _TV_DECODERS:
-                    results[backend] = None
-                    continue
-                try:
-                    ff = args.from_file
-                    if backend == "torchcodec":
-                        fn = partial(decode_torchcodec, fmt, path, data, ff)
-                    elif backend == "PIL":
-                        fn = partial(decode_pil, path, raw, ff)
-                    elif backend == "torchvision":
-                        fn = partial(decode_torchvision, fmt, path, data, ff)
-                    else:
-                        fn = partial(decode_ffmpeg, path, data, ff)
-                    fn()  # smoke
-                    times = bench(fn, num_exp=args.num_exp)
-                    results[backend] = _median_ms(times)
-                except Exception as e:
-                    results[backend] = None
-                    print(f"  [skip] {fmt} {res_label} {backend}: {str(e)[:80]}")
-            rows.append((fmt, res_label, size_kb, results))
+    for device in args.devices:
+        # nvJPEG is the only GPU decoder available on either side.
+        formats = ["jpeg"] if device == "cuda" else list(_EXT)
+        for fmt in formats:
+            for res_label in args.resolutions:
+                path = paths[(fmt, res_label)]
+                raw = path.read_bytes()
+                data = torch.frombuffer(bytearray(raw), dtype=torch.uint8)
+                size_kb = len(raw) / 1024.0
+                results = {}
+                for backend in backends:
+                    # torchvision has no avif/heic decoder; leave those cells blank.
+                    if backend == "torchvision" and fmt not in _TV_DECODERS:
+                        results[backend] = None
+                        continue
+                    # PIL is CPU-only and the FFmpeg path has no GPU JPEG decoder.
+                    if device == "cuda" and backend in ("PIL", "FFmpeg"):
+                        results[backend] = None
+                        continue
+                    try:
+                        ff = args.from_file
+                        if backend == "torchcodec":
+                            fn = partial(decode_torchcodec, fmt, path, data, ff, device)
+                        elif backend == "PIL":
+                            fn = partial(decode_pil, path, raw, ff)
+                        elif backend == "torchvision":
+                            fn = partial(
+                                decode_torchvision, fmt, path, data, ff, device
+                            )
+                        else:
+                            fn = partial(decode_ffmpeg, path, data, ff)
+                        if device == "cuda":
+                            fn = cuda_synced(fn)
+                        fn()  # smoke
+                        times = bench(fn, num_exp=args.num_exp)
+                        results[backend] = _median_ms(times)
+                    except Exception as e:
+                        results[backend] = None
+                        print(
+                            f"  [skip] {fmt} {device} {res_label} {backend}: {str(e)[:80]}"
+                        )
+                rows.append((fmt, device, res_label, size_kb, results))
 
     # ---- results table ----
     print(f"\n## Decode-to-tensor median latency (ms), 1 thread, {args.num_exp} runs\n")
     hdr = (
-        f"{'format':<7}{'res':<7}{'size KB':>9}{'torchcodec':>12}{'PIL':>9}"
+        f"{'format':<7}{'device':<7}{'res':<7}{'size KB':>9}{'torchcodec':>12}{'PIL':>9}"
         f"{'tv':>9}{'FFmpeg':>9}{'PIL/tc':>9}{'tv/tc':>9}{'FFmpeg/tc':>11}"
     )
     print(hdr)
@@ -293,7 +359,7 @@ def main():
             return "N/A"
         return f"{num / den:.2f}x"
 
-    for fmt, res_label, size_kb, r in rows:
+    for fmt, device, res_label, size_kb, r in rows:
         tc, pil, tv, ff = (
             r["torchcodec"],
             r["PIL"],
@@ -301,12 +367,53 @@ def main():
             r["FFmpeg"],
         )
         print(
-            f"{fmt:<7}{res_label:<7}{size_kb:>9.1f}{fmt_ms(tc):>12}{fmt_ms(pil):>9}"
-            f"{fmt_ms(tv):>9}{fmt_ms(ff):>9}{ratio(pil, tc):>9}{ratio(tv, tc):>9}"
-            f"{ratio(ff, tc):>11}"
+            f"{fmt:<7}{device:<7}{res_label:<7}{size_kb:>9.1f}{fmt_ms(tc):>12}"
+            f"{fmt_ms(pil):>9}{fmt_ms(tv):>9}{fmt_ms(ff):>9}{ratio(pil, tc):>9}"
+            f"{ratio(tv, tc):>9}{ratio(ff, tc):>11}"
         )
 
     print("\n(PIL/tc, tv/tc and FFmpeg/tc > 1.0 mean torchcodec is faster.)")
+
+    # ---- CUDA batch decode: torchcodec vs torchvision, both batched ----
+    if "cuda" in args.devices:
+        print(
+            f"\n## Batch decode JPEG on CUDA, median ms, {args.num_exp} runs "
+            f"(same image repeated)\n"
+        )
+        bhdr = (
+            f"{'res':<7}{'batch':<7}{'torchcodec':>12}{'tv':>9}{'tv/tc':>9}"
+            f"{'tc/img':>10}{'tv/img':>10}"
+        )
+        print(bhdr)
+        print("-" * len(bhdr))
+        for res_label in args.resolutions:
+            path = paths[("jpeg", res_label)]
+            data = torch.frombuffer(bytearray(path.read_bytes()), dtype=torch.uint8)
+            for bs in args.batch_sizes:
+                b = {}
+                for backend in ("torchcodec", "torchvision"):
+                    fn = cuda_synced(
+                        make_batch_decode_fn(
+                            backend, path, data, args.from_file, bs, "cuda"
+                        )
+                    )
+                    try:
+                        fn()  # smoke
+                        b[backend] = _median_ms(bench(fn, num_exp=args.num_exp))
+                    except Exception as e:
+                        b[backend] = None
+                        print(
+                            f"  [skip] batch {res_label} {bs} {backend}: {str(e)[:80]}"
+                        )
+                tc, tv = b["torchcodec"], b["torchvision"]
+                tc_img = tc / bs if tc is not None else None
+                tv_img = tv / bs if tv is not None else None
+                print(
+                    f"{res_label:<7}{bs:<7}{fmt_ms(tc):>12}{fmt_ms(tv):>9}"
+                    f"{ratio(tv, tc):>9}{fmt_ms(tc_img):>10}{fmt_ms(tv_img):>10}"
+                )
+        print("\n(tv/tc > 1.0 means torchcodec is faster.)")
+
     tmp.cleanup()
 
 


### PR DESCRIPTION
Results of both CPU and CUDA decoders:

```
~/dev/torchcodec-cuda (main*) » python benchmarks/decoders/benchmark_image_decoders.py                                                                                         nicolashug@nicolashug-fedora-PW0H326Y
torch.get_num_threads()=1, OMP_NUM_THREADS=1
Note: libavif/dav1d internal threading is not exposed by decode_avif (library default).
Source: in-memory bytes

## Decode-to-tensor median latency (ms), 1 thread, 50 runs

format device res      size KB  torchcodec      PIL       tv   FFmpeg   PIL/tc    tv/tc  FFmpeg/tc
--------------------------------------------------------------------------------------------------
jpeg   cpu    320p        71.1       0.786    1.034    0.782    1.393    1.32x    1.00x      1.77x
jpeg   cpu    480p       138.0       1.576    2.229    1.573    2.572    1.41x    1.00x      1.63x
jpeg   cpu    720p       251.4       3.056    4.477    3.068    4.305    1.46x    1.00x      1.41x
jpeg   cpu    1080p      446.4       5.981    9.249    6.013    8.224    1.55x    1.01x      1.37x
png    cpu    320p       372.5       4.446    5.124    4.441    7.606    1.15x    1.00x      1.71x
png    cpu    480p       753.3       9.743   11.188    9.730   16.407    1.15x    1.00x      1.68x
png    cpu    720p      1431.0      20.758   23.930   20.749   34.890    1.15x    1.00x      1.68x
png    cpu    1080p     2634.8      43.975   51.255   44.150   74.635    1.17x    1.00x      1.70x
webp   cpu    320p        66.2       3.671    4.226    3.686    9.473    1.15x    1.00x      2.58x
webp   cpu    480p       124.1       7.266    8.318    7.278   18.362    1.14x    1.00x      2.53x
webp   cpu    720p       202.1      12.736   15.043   12.706   31.318    1.18x    1.00x      2.46x
webp   cpu    1080p      327.6      22.597   28.618   22.576   54.957    1.27x    1.00x      2.43x
gif    cpu    320p       157.7       2.284    1.660    2.445    1.781    0.73x    1.07x      0.78x
gif    cpu    480p       325.3       5.132    3.640    5.508    3.644    0.71x    1.07x      0.71x
gif    cpu    720p       656.5      11.364    7.992   12.290    7.364    0.70x    1.08x      0.65x
gif    cpu    1080p     1292.4      25.085   17.451   27.322   15.908    0.70x    1.09x      0.63x
avif   cpu    320p        69.1       5.266    5.719      N/A   10.262    1.09x      N/A      1.95x
avif   cpu    480p       130.3      10.378   11.241      N/A   19.951    1.08x      N/A      1.92x
avif   cpu    720p       221.3      17.731   19.655      N/A   33.666    1.11x      N/A      1.90x
avif   cpu    1080p      341.1      28.005   33.355      N/A   53.226    1.19x      N/A      1.90x
heic   cpu    320p       136.4      19.211   19.573      N/A   12.441    1.02x      N/A      0.65x
heic   cpu    480p       273.8      38.346   38.201      N/A   25.298    1.00x      N/A      0.66x
heic   cpu    720p       509.5      71.578   64.586      N/A   48.758    0.90x      N/A      0.68x
heic   cpu    1080p      899.0     136.545  119.747      N/A   91.335    0.88x      N/A      0.67x
jpeg   cuda   320p        71.1       0.750      N/A    0.757      N/A      N/A    1.01x        N/A
jpeg   cuda   480p       138.0       1.466      N/A    1.434      N/A      N/A    0.98x        N/A
jpeg   cuda   720p       251.4       2.735      N/A    2.698      N/A      N/A    0.99x        N/A
jpeg   cuda   1080p      446.4       5.145      N/A    5.083      N/A      N/A    0.99x        N/A

(PIL/tc, tv/tc and FFmpeg/tc > 1.0 mean torchcodec is faster.)

## Batch decode JPEG on CUDA, median ms, 50 runs (same image repeated)

res    batch    torchcodec       tv    tv/tc    tc/img    tv/img
----------------------------------------------------------------
320p   1             0.749    0.744    0.99x     0.749     0.744
320p   16           10.719   10.520    0.98x     0.670     0.657
320p   64           42.830   41.775    0.98x     0.669     0.653
480p   1             1.460    1.461    1.00x     1.460     1.461
480p   16           21.164   20.684    0.98x     1.323     1.293
480p   64           84.132   82.215    0.98x     1.315     1.285
720p   1             2.723    2.714    1.00x     2.723     2.714
720p   16           39.788   39.196    0.99x     2.487     2.450
720p   64          159.036  155.975    0.98x     2.485     2.437
1080p  1             5.149    5.082    0.99x     5.149     5.082
1080p  16           74.006   72.609    0.98x     4.625     4.538
1080p  64          295.248  289.212    0.98x     4.613     4.519

(tv/tc > 1.0 means torchcodec is faster.)
```