### PR TITLE
materialize raw frame tests

### DIFF
--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3773,12 +3773,12 @@ class TestBlocks:
         def sample(value_8bit):
             return value_8bit << (case.bit_depth(device) - 8)
 
-        _, U, V = planes
+        Y, U, V = planes
         U.fill_(sample(128))  # no color
         V.fill_(sample(128))
 
         for luma, expected in ((235, 255), (16, 0)):
-            planes[0].fill_(sample(luma))
+            Y.fill_(sample(luma))
             data = converter.convert(frame).data.to(torch.int16)
             # Loose bound: swscale's bt2020 handling lands a couple of levels
             # short of the endpoints. Misreading the depth is off by a factor

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -11,6 +11,7 @@ import math
 import queue
 import threading
 from functools import partial
+from typing import NamedTuple
 
 import numpy
 import pytest
@@ -3417,23 +3418,49 @@ def _block_devices():
     return ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
 
 
+# How many of a sample's bits each pixel format we expect to see actually
+# carries. Note that nv12's "12" is about chroma subsampling, not depth.
+_PIX_FMT_DEPTHS = {
+    "yuv420p": 8,
+    "yuv444p": 8,
+    "nv12": 8,
+    "yuv420p10le": 10,
+    "yuv420p12le": 12,
+}
+
+
+class _MaterializeCase(NamedTuple):
+    """A video, and the pixel format its frames come out in on each device."""
+
+    video: object
+    cpu_pix_fmt: str
+    cuda_pix_fmt: str
+
+    def pix_fmt(self, device):
+        return self.cuda_pix_fmt if device == "cuda" else self.cpu_pix_fmt
+
+    def bit_depth(self, device):
+        return _PIX_FMT_DEPTHS[self.pix_fmt(device)]
+
+
 # Videos spanning the pixel-format axes materialize() has to handle: 4:2:0 vs
 # 4:4:4 chroma, even vs odd dims (chroma rounds up), and 8- vs 10-/12-bit
 # (uint8 vs uint16 planes). All are YUV, so planes are (Y, U, V).
 _MATERIALIZE_VIDEOS = (
-    NASA_VIDEO,  # yuv420p, 8-bit, even dims
-    TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9,  # yuv420p, 8-bit, odd dims
-    TESTSRC2_ODD_HEIGHT_AND_WIDTH_444,  # yuv444p, 8-bit, full-res chroma
-    TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9_10BIT,  # yuv420p10le, 10-bit -> uint16
-    TEST_SRC_2_12BIT_HDR,  # yuv420p12le, 12-bit -> uint16
+    _MaterializeCase(NASA_VIDEO, "yuv420p", "nv12"),  # even dims
+    _MaterializeCase(TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9, "yuv420p", "nv12"),  # odd dims
+    # 4:4:4 (full-res chroma): NVDEC can't decode it, so CUDA falls back to the
+    # CPU and the frame keeps its native format.
+    _MaterializeCase(TESTSRC2_ODD_HEIGHT_AND_WIDTH_444, "yuv444p", "yuv444p"),
+    # NVDEC is asked for 8-bit surfaces, so the 10-/12-bit sources come out of
+    # it as nv12 - only the CPU sees their native depth.
+    _MaterializeCase(TESTSRC2_ODD_HEIGHT_AND_WIDTH_VP9_10BIT, "yuv420p10le", "nv12"),
+    _MaterializeCase(TEST_SRC_2_12BIT_HDR, "yuv420p12le", "nv12"),
 )
 
 
-def _is_high_depth(pix_fmt):
-    # Whether samples need uint16. nv12/nv21 contain "12"/"21" but are 8-bit.
-    if pix_fmt in ("nv12", "nv21", "nv16", "nv24"):
-        return False
-    return any(token in pix_fmt for token in ("10", "12", "14", "16"))
+def _materialize_ids(case):
+    return case.video.path.stem
 
 
 def _planes_equal(a, b):
@@ -3682,14 +3709,14 @@ class TestBlocks:
         frame = next(self._decode(decoder, self._demux(demuxer)))
         return frame, converter
 
-    @pytest.mark.parametrize("video", _MATERIALIZE_VIDEOS)
+    @pytest.mark.parametrize("case", _MATERIALIZE_VIDEOS, ids=_materialize_ids)
     @pytest.mark.parametrize("device", _block_devices())
-    def test_materialize_structure(self, video, device):
+    def test_materialize_structure(self, case, device):
         # planes shape/dtype/device and the accompanying metadata.
-        frame, converter = self._first_frame(video.path, device)
+        frame, converter = self._first_frame(case.video.path, device)
         planes, pix_fmt, colorspace, color_range = frame.materialize()
 
-        assert isinstance(pix_fmt, str) and pix_fmt
+        assert pix_fmt == case.pix_fmt(device)
         assert colorspace in ("bt709", "bt2020nc", "smpte170m", "unknown")
         assert color_range in ("tv", "pc", "unknown")  # FFmpeg has only these
 
@@ -3700,10 +3727,7 @@ class TestBlocks:
             assert plane.ndim == 2
             assert plane.device.type == frame.device
 
-        # TODO_NOW getting uint16 isn't expected - we never go
-        # through P016 on CUDA, for example. There's a TODO about handling HDr
-        # in general, should figure that out then.
-        expected_dtype = torch.uint16 if _is_high_depth(pix_fmt) else torch.uint8
+        expected_dtype = torch.uint16 if case.bit_depth(device) > 8 else torch.uint8
         assert all(plane.dtype == expected_dtype for plane in planes)
 
         Y, U, V = planes
@@ -3718,6 +3742,49 @@ class TestBlocks:
             (width + (1 << log2_w) - 1) >> log2_w,
         )
         assert U.shape == V.shape == expected_chroma_shape
+
+    @pytest.mark.needs_cuda
+    @pytest.mark.parametrize("case", _MATERIALIZE_VIDEOS, ids=_materialize_ids)
+    def test_materialize_cuda_planes_match_cpu(self, case):
+        # NVDEC and FFmpeg's software decoder produce the very same samples, so
+        # the raw planes must match bit-for-bit across devices.
+        if case.bit_depth("cuda") != case.bit_depth("cpu"):
+            pytest.skip("NVDEC gives us 8-bit surfaces for this source.")
+
+        cpu_planes, *_ = self._first_frame(case.video.path, "cpu")[0].materialize()
+        cuda_planes, *_ = self._first_frame(case.video.path, "cuda")[0].materialize()
+
+        assert len(cpu_planes) == len(cuda_planes)
+        for cpu_plane, cuda_plane in zip(cpu_planes, cuda_planes):
+            assert _planes_equal(cpu_plane, cuda_plane.cpu())
+
+    @pytest.mark.parametrize("case", _MATERIALIZE_VIDEOS, ids=_materialize_ids)
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_color_converter_honors_sample_bit_depth(self, case, device):
+        # Paint the planes with the limited-range black and white points,
+        # expressed in the frame's own sample scale, and check the converter
+        # maps them to 0 and 255. This is what pins its notion of how many bits
+        # a sample carries: misreading the depth in either direction sends both
+        # ends to the same extreme.
+        frame, converter = self._first_frame(case.video.path, device)
+        planes, _, _, color_range = frame.materialize()
+        assert color_range in ("tv", "unknown")  # unknown is treated as tv
+
+        def sample(value_8bit):
+            return value_8bit << (case.bit_depth(device) - 8)
+
+        _, U, V = planes
+        U.fill_(sample(128))  # no color
+        V.fill_(sample(128))
+
+        for luma, expected in ((235, 255), (16, 0)):
+            planes[0].fill_(sample(luma))
+            data = converter.convert(frame).data.to(torch.int16)
+            # Loose bound: swscale's bt2020 handling lands a couple of levels
+            # short of the endpoints. Misreading the depth is off by a factor
+            # of 16 or 64, which lands at the opposite endpoint - never 5
+            # levels away.
+            assert (data - expected).abs().max() <= 5
 
     @pytest.mark.parametrize("device", _block_devices())
     def test_materialize_mutation_visible_in_color_convert(self, device):
@@ -3753,13 +3820,13 @@ class TestBlocks:
         planes_a[0][0, 0] = original ^ 0xFF  # flip first pixel in Y
         assert int(planes_b[0][0, 0].item()) == (original ^ 0xFF)
 
-    @pytest.mark.parametrize("video", _MATERIALIZE_VIDEOS)
+    @pytest.mark.parametrize("case", _MATERIALIZE_VIDEOS, ids=_materialize_ids)
     @pytest.mark.parametrize("device", _block_devices())
-    def test_materialize_planes_outlive_frame(self, video, device):
+    def test_materialize_planes_outlive_frame(self, case, device):
         # The views keep the frame alive, so they stay valid (readable and
         # writable) after the DecodedFrame they came from is dropped.
         # grep for this test name to see associated comment in the code.
-        frame, _ = self._first_frame(video.path, device)
+        frame, _ = self._first_frame(case.video.path, device)
         planes, *_ = frame.materialize()
         saved = [plane.clone() for plane in planes]
 


### PR DESCRIPTION
Add more tests for the pixel format handling of blocks APIs. Still a bit wonky because the CUDA path doesn't handle HDR yet. Will be cleaned up by https://github.com/meta-pytorch/torchcodec/pull/1625 