### PR TITLE
Properly handle DISCARD packets in CUDA interface

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -700,6 +700,10 @@ int BetaCudaDeviceInterface::send_packet(ReferenceAVPacket& packet) {
   cuvid_packet.flags = CUVID_PKT_TIMESTAMP;
   cuvid_packet.timestamp = packet_to_send->pts;
 
+  if (packet_to_send->flags & AV_PKT_FLAG_DISCARD) {
+    discarded_timestamps_.insert(cuvid_packet.timestamp);
+  }
+
   return send_cuvid_packet(cuvid_packet);
 }
 
@@ -783,6 +787,13 @@ int BetaCudaDeviceInterface::receive_frame(UniqueAVFrame& av_frame) {
   CudaContextGuard context_guard(device_.index());
   if (decoding_on_cpu_) {
     return cpu_interface_->receive_frame(av_frame);
+  }
+
+  // Drop those packets that were marked as discard. We only wanted to decode
+  // those, not to return them.
+  while (!ready_frames_.empty() &&
+         discarded_timestamps_.erase(ready_frames_.front().timestamp) > 0) {
+    ready_frames_.pop();
   }
 
   if (ready_frames_.empty()) {
@@ -1130,6 +1141,7 @@ void BetaCudaDeviceInterface::flush() {
 
   std::queue<CUVIDPARSERDISPINFO> empty_queue;
   std::swap(ready_frames_, empty_queue);
+  discarded_timestamps_.clear();
 
   send_seqhdr_packet();
 }

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <queue>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "nvcuvid_include/cuviddec.h"
@@ -149,6 +150,14 @@ class BetaCudaDeviceInterface : public DeviceInterface {
   CUVIDEOFORMATEX parser_ext_info_ = {};
 
   std::queue<CUVIDPARSERDISPINFO> ready_frames_;
+
+  // The packets flagged AV_PKT_FLAG_DISCARD must be decoded, but their frames
+  // must not be returned (that's how libavcodec does it). We track the
+  // timestamps of those packets and drop the corresponding frames in
+  // receive_frame(). We rely on the packet's pts to identify it: it's not
+  // ideal, the pts may be non-unique or missing. But that's working so far.
+  // Unfortuntely, NVCUVID doesn't give us any other way to pass down that info.
+  std::unordered_set<CUvideotimestamp> discarded_timestamps_;
 
   bool eof_sent_ = false;
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3820,15 +3820,6 @@ class TestBlocks:
     )
     @pytest.mark.parametrize("device", _block_devices())
     def test_matches_video_decoder(self, video, decode_method, device):
-        # TODO_API_BREAKDOWN CORRECTNESS P1: this fails on CUDA and must be fixed. The blocks
-        # Demuxer doesn't honor AV_PKT_FLAG_DISCARD (unlike SingleStreamDecoder),
-        # so it emits the extra frames trimmed away by the mp4 edit list.
-        # This is kinda related to exact and approximate mode (not exposed on
-        # Blocks (yet??)) so we might want to address that once we have
-        # addressed seeking in the blocks - if we ever support that.
-        if device == "cuda" and video is DISCARD_FIRST_KEYFRAME_VIDEO:
-            pytest.skip("Blocks pipeline does not handle this asset on CUDA yet.")
-
         if (
             video
             in (
@@ -3850,6 +3841,23 @@ class TestBlocks:
         torch.testing.assert_close(
             got.duration_seconds, ref.duration_seconds, atol=0, rtol=0
         )
+
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_discard_first_keyframe(self, device):
+        # The leading GOP of this asset is trimmed by an mp4 edit list, so its
+        # packets are flagged AV_PKT_FLAG_DISCARD: they must be decoded (the
+        # frame at pts=0 references the discarded keyframe) but never output.
+        expected_pts = [pytest.approx(0.04 * i, abs=1e-6) for i in range(25)]
+
+        path = DISCARD_FIRST_KEYFRAME_VIDEO.path
+        frames = self._decode_sequential(path, device)
+        assert [frame.pts_seconds for frame in frames] == expected_pts
+
+        # Seeking to the start makes FFmpeg land on the discarded keyframe, so
+        # those packets are sent down a second time: the tracking must survive
+        # the seek.
+        frames = list(self._frames_after_seek(self._make_blocks(path, device), 0))
+        assert [frame.pts_seconds for frame in frames] == expected_pts
 
     @pytest.mark.parametrize(
         "video", (NASA_VIDEO, NASA_VIDEO_HDR, TEST_SRC_2_12BIT_HDR)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -43,6 +43,7 @@ from torchcodec._core.ops import (
 from .utils import (
     all_supported_devices,
     assert_frames_equal,
+    DISCARD_FIRST_KEYFRAME_VIDEO,
     get_python_version,
     NASA_AUDIO,
     NASA_AUDIO_MP3,
@@ -91,6 +92,24 @@ class TestVideoDecoderOps:
         seek_to_pts(decoder, -1e-4)
         frame0, _, _ = get_next_frame(decoder)
         assert_frames_equal(frame0, reference_frame0.to(device))
+
+    @pytest.mark.parametrize("device", all_supported_devices())
+    def test_discard_first_keyframe(self, device):
+        # The leading GOP of this asset is trimmed by an mp4 edit list, so its
+        # packets are flagged AV_PKT_FLAG_DISCARD: they must be decoded (the
+        # frame at pts=0 references the discarded keyframe) but never output.
+        # We call get_next_frame() without seeking first, so nothing sets the
+        # decoder's cursor and nothing filters those frames out by pts: this
+        # only passes if the decoding backend drops them itself. In other words,
+        # we're exercising the decoder/interface, not the logic in
+        # SingleStreamDecoder.
+        decoder = create_from_file(str(DISCARD_FIRST_KEYFRAME_VIDEO.path))
+        device, device_variant = unsplit_device_str(device)
+        add_video_stream(decoder, device=device, device_variant=device_variant)
+
+        for expected_pts in (0.0, 0.04, 0.08):
+            _, pts_seconds, _ = get_next_frame(decoder)
+            assert pts_seconds.item() == pytest.approx(expected_pts, abs=1e-6)
 
     @pytest.mark.parametrize("device", all_supported_devices())
     def test_get_frame_at_pts(self, device):


### PR DESCRIPTION
The libavcodec convention is that DISCARD packets should be sent to the codec. It's up to the codec itself to then not return the associated data (via EAGAIN). DISCARD packets *must* be decoded still: they may contain necessary info that's needed to decode subsequent frames.

Our (beta) CUDA interface was decoding them, but we were returning their data. Now, we don't.

The error path was never exercised before through VideoDecoder because of side-effects (i.e. luck), but it *was* an issue when relying on the core ops, and the blocks API exposed it to. It's now fixed in both and we have one non-regression test for each case.

This is a follow-up and complementary fix to https://github.com/meta-pytorch/torchcodec/pull/1504