### PR TITLE
Add scan() to Demuxer

### DIFF
--- a/examples/decoding/blocks.py
+++ b/examples/decoding/blocks.py
@@ -190,9 +190,89 @@ packet_decoder.reset()
 
 frames = color_convert(color_converter, decode(packet_decoder, demux(demuxer)))
 landed_on = next(frames)
-target = next(frame for frame in frames if frame.pts_seconds >= seconds)
+# The frame *playing* at a timestamp is the first one that hasn't finished
+# playing by then. Not `pts_seconds >= seconds`, which skips it whenever the
+# timestamp falls inside a frame rather than on its boundary.
+target = next(
+    frame
+    for frame in frames
+    if frame.pts_seconds + frame.duration_seconds > seconds
+)
 print(f"asked for {seconds}s, landed on {landed_on.pts_seconds:.3f}s, "
       f"target frame at {target.pts_seconds:.3f}s")
+
+# %%
+# Scanning
+# --------
+#
+# ``Demuxer.scan()`` demuxes the whole stream once, without decoding anything,
+# and returns a ``StreamIndex``: one entry per frame, in presentation order.
+# This is the only way to know a stream's exact frame count, timestamps and
+# keyframe positions - a container header can be wrong about all of them. It
+# costs one pass over the file, and it leaves the demuxer back at the start.
+demuxer = Demuxer(video_path)
+index = demuxer.scan()
+packet_decoder = PacketDecoder(demuxer, device=device)
+color_converter = ColorConverter(device=device)
+
+print(f"{len(index)} frames at {index.average_fps} fps, "
+      f"from {index.begin_stream_seconds}s to {index.end_stream_seconds}s")
+
+# %%
+# The index is also what gives the blocks frame *indices*, which they otherwise
+# don't have at all: ``index_at()`` maps a timestamp to the frame on screen
+# then, and ``pts_seconds`` maps back. That's enough to build ``get_frame_at``,
+# or a clip sampler, on top of the blocks.
+i = index.index_at(seconds)
+print(f"frame {i} is on screen at {seconds}s, and starts at {index.pts_seconds[i]}s")
+
+# %%
+# Keyframes
+# ^^^^^^^^^
+#
+# ``is_key_frame`` is a mask over all the frames, and ``key_frame_indices`` the
+# same thing as a list of indices. Keyframes are the frames that decode on
+# their own, which makes them the cheap ones to reach: seeking to a keyframe's
+# timestamp lands exactly on it, and the very next frame out of the decoder is
+# the one you asked for - no decoding forward, nothing to drop.
+#
+# That makes a keyframe-only sampler about as cheap as video decoding gets,
+# which is what you want for thumbnails or coarse previews.
+key_frames = index.key_frame_indices
+print(f"{len(key_frames)} keyframes out of {len(index)} frames, "
+      f"at {index.pts_seconds[key_frames].tolist()}")
+
+thumbnails = []
+for k in key_frames.tolist():
+    demuxer.seek(index.pts_seconds[k])
+    packet_decoder.reset()
+    raw_frame = next(decode(packet_decoder, demux(demuxer)))
+    thumbnails.append(color_converter.convert(raw_frame))
+
+print(f"{len(thumbnails)} thumbnails at "
+      f"{[round(f.pts_seconds, 3) for f in thumbnails]}")
+
+# %%
+# Exact seeking
+# ^^^^^^^^^^^^^
+#
+# One last thing the index buys you, which most files never need.
+# ``seek(seconds)`` already lands on the keyframe at or before the target - but
+# FFmpeg resolves a seek against *decode* timestamps, so on a file whose
+# keyframes are reordered it can land on one that is *displayed after* the
+# target, leaving the frames in between unreachable however far forward you
+# decode. ``key_frame_seconds_for()`` gives you that keyframe's own timestamp
+# instead, which always lands where you meant.
+#
+# The two are the same call on the overwhelming majority of files; this is the
+# whole of what separates :class:`~torchcodec.decoders.VideoDecoder`'s
+# ``seek_mode="exact"`` from ``"approximate"`` for a timestamp lookup.
+demuxer.seek(index.key_frame_seconds_for(seconds))
+packet_decoder.reset()
+
+frames = color_convert(color_converter, decode(packet_decoder, demux(demuxer)))
+target = next(f for f in frames if f.pts_seconds >= index.pts_seconds[i])
+print(f"frame {i} at {target.pts_seconds:.3f}s")
 
 # %%
 # Raw frames

--- a/src/torchcodec/_core/Demuxer.cpp
+++ b/src/torchcodec/_core/Demuxer.cpp
@@ -6,6 +6,7 @@
 
 #include "Demuxer.h"
 
+#include <algorithm>
 #include <sstream>
 
 #include "StableABICompat.h"
@@ -162,6 +163,72 @@ void Demuxer::seek(double seconds) {
   STD_TORCH_CHECK(
       status >= 0,
       get_seek_error_message(format_context_.get(), desired_pts, status));
+}
+
+namespace {
+struct ScannedPacket {
+  int64_t pts;
+  int64_t duration;
+  bool is_key_frame;
+};
+} // namespace
+
+StreamIndex Demuxer::scan() {
+  std::vector<ScannedPacket> packets;
+  if (stream_->nb_frames > 0) {
+    packets.reserve(static_cast<size_t>(stream_->nb_frames));
+  }
+
+  seek(0);
+
+  while (true) {
+    ReferenceAVPacket packet(auto_packet_);
+    int status =
+        read_next_packet(format_context_.get(), active_stream_index_, packet);
+    if (status == AVERROR_EOF) {
+      break;
+    }
+    STD_TORCH_CHECK(
+        status >= AVSUCCESS,
+        "Could not read frame from input file: ",
+        get_ffmpeg_error_string_from_error_code(status));
+
+    if (packet->flags & AV_PKT_FLAG_DISCARD) {
+      continue;
+    }
+
+    packets.push_back(
+        {get_pts_or_dts(packet),
+         packet->duration,
+         (packet->flags & AV_PKT_FLAG_KEY) != 0});
+  }
+
+  std::stable_sort(
+      packets.begin(),
+      packets.end(),
+      [](const ScannedPacket& a, const ScannedPacket& b) {
+        return a.pts < b.pts;
+      });
+
+  seek(0);
+
+  auto num_frames = static_cast<int64_t>(packets.size());
+  StreamIndex index{
+      torch::stable::empty({num_frames}, kStableInt64),
+      torch::stable::empty({num_frames}, kStableInt64),
+      torch::stable::empty({num_frames}, kStableBool),
+      stream_->time_base};
+
+  auto pts = mutable_accessor<int64_t, 1>(index.pts);
+  auto duration = mutable_accessor<int64_t, 1>(index.duration);
+  auto is_key_frame = mutable_accessor<bool, 1>(index.is_key_frame);
+  for (int64_t i = 0; i < num_frames; ++i) {
+    pts[i] = packets[i].pts;
+    duration[i] = packets[i].duration;
+    is_key_frame[i] = packets[i].is_key_frame;
+  }
+
+  return index;
 }
 
 UniqueAVPacket Demuxer::next_packet() {

--- a/src/torchcodec/_core/Demuxer.h
+++ b/src/torchcodec/_core/Demuxer.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "AVIOContextHolder.h"
 #include "FFMPEGCommon.h"
@@ -30,6 +31,16 @@ std::string get_seek_error_message(
     int64_t desired_pts,
     int status);
 
+// The frames of the active stream, in presentation order: three parallel
+// tensors of length N, plus the time base `pts` and `duration` are expressed
+// in.
+struct StreamIndex {
+  torch::stable::Tensor pts; // int64 [N]
+  torch::stable::Tensor duration; // int64 [N]
+  torch::stable::Tensor is_key_frame; // bool [N]
+  AVRational time_base;
+};
+
 // Demux building block: owns an AVFormatContext, selects one video stream, and
 // yields its (compressed) packets. Does no decoding. Not thread-safe.
 class FORCE_PUBLIC_VISIBILITY Demuxer {
@@ -47,6 +58,11 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   UniqueAVPacket next_packet();
 
   void seek(double seconds);
+
+  // Demuxes the entire stream, without decoding, and returns one entry per
+  // frame sorted by pts. Leaves the demuxer back at the start of the stream,
+  // and keeps no state of its own.
+  StreamIndex scan();
 
   AVStream* active_stream() const {
     return stream_;

--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -35,6 +35,7 @@ FFMPEG_OP_NAMES = frozenset(
         "_blocks_create_demuxer_from_file_like",
         "_blocks_demuxer_next_packet",
         "_blocks_demuxer_seek",
+        "_blocks_demuxer_scan",
         "_blocks_create_packet_decoder",
         "_blocks_packet_decoder_send_packet",
         "_blocks_packet_decoder_send_eof",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -105,6 +105,7 @@ _blocks_demuxer_next_packet = (
     torch.ops.torchcodec_ns._blocks_demuxer_next_packet.default
 )
 _blocks_demuxer_seek = torch.ops.torchcodec_ns._blocks_demuxer_seek.default
+_blocks_demuxer_scan = torch.ops.torchcodec_ns._blocks_demuxer_scan.default
 _blocks_create_packet_decoder = (
     torch.ops.torchcodec_ns._blocks_create_packet_decoder.default
 )

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -82,6 +82,8 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def("_blocks_demuxer_next_packet(Tensor(a!) demuxer) -> (Tensor, bool)");
   m.def("_blocks_demuxer_seek(Tensor(a!) demuxer, float seconds) -> ()");
   m.def(
+      "_blocks_demuxer_scan(Tensor(a!) demuxer) -> (Tensor, Tensor, Tensor, int, int)");
+  m.def(
       "_blocks_create_packet_decoder(Tensor demuxer, *, int? num_threads=None, str device=\"cpu\") -> Tensor");
   m.def(
       "_blocks_packet_decoder_send_packet(Tensor(a!) decoder, Tensor packet) -> int");
@@ -865,6 +867,25 @@ void _blocks_demuxer_seek(torch::stable::Tensor& demuxer, double seconds) {
   unwrap_tensor_to_pointer<Demuxer>(demuxer)->seek(seconds);
 }
 
+// (pts, duration, is_key_frame, time_base_num, time_base_den). pts and duration
+// are int64 [N] in time-base units rather than seconds
+using OpsScanOutput = std::tuple<
+    torch::stable::Tensor,
+    torch::stable::Tensor,
+    torch::stable::Tensor,
+    int64_t,
+    int64_t>;
+
+OpsScanOutput _blocks_demuxer_scan(torch::stable::Tensor& demuxer) {
+  StreamIndex index = unwrap_tensor_to_pointer<Demuxer>(demuxer)->scan();
+  return std::make_tuple(
+      index.pts,
+      index.duration,
+      index.is_key_frame,
+      static_cast<int64_t>(index.time_base.num),
+      static_cast<int64_t>(index.time_base.den));
+}
+
 torch::stable::Tensor _blocks_create_packet_decoder(
     torch::stable::Tensor& demuxer,
     std::optional<int64_t> num_threads,
@@ -1558,6 +1579,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl(
       "_blocks_demuxer_next_packet", TORCH_BOX(&_blocks_demuxer_next_packet));
   m.impl("_blocks_demuxer_seek", TORCH_BOX(&_blocks_demuxer_seek));
+  m.impl("_blocks_demuxer_scan", TORCH_BOX(&_blocks_demuxer_scan));
   m.impl(
       "_blocks_create_packet_decoder",
       TORCH_BOX(&_blocks_create_packet_decoder));

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -16,7 +16,7 @@ API_breakdown_claude_plan.md for the design and rationale.
 """
 
 from ._color_converter import ColorConverter
-from ._demuxer import Demuxer
+from ._demuxer import Demuxer, StreamIndex
 from ._frame import Packet, RawFrame
 from ._packet_decoder import PacketDecoder
 
@@ -26,7 +26,9 @@ __all__ = [
     "ColorConverter",
     "Packet",
     "RawFrame",
+    "StreamIndex",
 ]
 
-# TODO_API_BREAKDOWN FEAT P1 we probably need a way to expose metadata -
-# something that would avoid using VideoDecoder?
+# TODO_API_BREAKDOWN FEAT P1 we probably need a way to expose the *header*
+# metadata - something that would avoid using VideoDecoder? Demuxer.scan()
+# covers the content-derived half of that.

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -28,6 +28,10 @@ from ._frame import Packet
 # specific timestamps for sampling?
 
 
+# TODO_API_BREAKDOWN DESIGN P1: need to figure out the right API for this.
+# StreamIndex? the fields? The methods?
+# We'll have a big problem if/when we implement multi-stream demuxing - and
+# audio!
 @dataclass
 class StreamIndex:
     """The content of a video stream, as returned by :meth:`Demuxer.scan`.

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -7,18 +7,147 @@
 from __future__ import annotations
 
 import io
+from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 
+import torch
 from torch import Tensor
 
 from torchcodec._core._decoder_utils import create_demuxer
-from torchcodec._core.ops import _blocks_demuxer_next_packet, _blocks_demuxer_seek
+from torchcodec._core.ops import (
+    _blocks_demuxer_next_packet,
+    _blocks_demuxer_scan,
+    _blocks_demuxer_seek,
+)
 
 from ._frame import Packet
 
 # TODO_API_BREAKDOWN FEAT PERF Do we want / need to support 'batch-like' APIs
 # were containers are pre-allocated for perf? Like if a user wants to decode
 # specific timestamps for sampling?
+
+
+@dataclass
+class StreamIndex:
+    """The content of a video stream, as returned by :meth:`Demuxer.scan`.
+
+    One entry per frame, in presentation order. Everything here is derived from
+    the packets of the stream rather than from the container header, so the
+    values are exact.
+
+    Timestamps are stored in the stream's own time base and converted to
+    seconds on access, which is what makes those conversions exact: a frame's
+    end time is ``(pts + duration)`` converted once, not ``pts_seconds +
+    duration_seconds``, which rounds twice and can land on the wrong side of a
+    frame boundary.
+
+    Attributes:
+        is_key_frame (torch.Tensor): bool ``[N]``, whether each frame is a
+            :term:`keyframe`.
+    """
+
+    is_key_frame: Tensor
+    _pts: Tensor
+    _duration: Tensor
+    _time_base_num: int
+    _time_base_den: int
+
+    def __len__(self) -> int:
+        """The number of frames in the stream."""
+        return self.is_key_frame.shape[0]
+
+    @cached_property
+    def pts_seconds(self) -> Tensor:
+        """float64 ``[N]``, the presentation timestamp of each frame."""
+        return self._to_seconds(self._pts)
+
+    @cached_property
+    def duration_seconds(self) -> Tensor:
+        """float64 ``[N]``, how long each frame is displayed for."""
+        return self._to_seconds(self._duration)
+
+    @cached_property
+    def key_frame_indices(self) -> Tensor:
+        """int64 ``[K]``, the indices of the :term:`keyframe`\\ s."""
+        return self.is_key_frame.nonzero().squeeze(1)
+
+    @cached_property
+    def begin_stream_seconds(self) -> float:
+        """Presentation timestamp of the first frame."""
+        return float(self.pts_seconds[0])
+
+    @cached_property
+    def end_stream_seconds(self) -> float:
+        """Timestamp at which the last frame stops being displayed."""
+        # max(), not [-1]: durations vary, so the frame that finishes last
+        # isn't necessarily the one that starts last. This is how
+        # end_stream_pts_from_content is accumulated in SingleStreamDecoder.
+        return float(self._end_seconds.max())
+
+    @property
+    def average_fps(self) -> float:
+        """Average number of frames per second over the stream."""
+        return len(self) / (self.end_stream_seconds - self.begin_stream_seconds)
+
+    def index_at(self, seconds: float) -> int:
+        """Index of the frame that is being displayed at ``seconds``.
+
+        A timestamp outside of the stream gives the frame closest to it, i.e.
+        the first or the last one.
+        """
+        # First frame that hasn't finished playing by `seconds`, which is
+        # get_frame_played_at()'s criterion (frame_start <= t < frame_end,
+        # SingleStreamDecoder.cpp) expressed as a search rather than a scan of
+        # decoded frames. Note it is *not* seconds_to_index_lower_bound(), which
+        # compares against next_pts and so answers differently for a timestamp
+        # falling in a gap between two frames.
+        index = int(torch.searchsorted(self._end_seconds, seconds, right=True))
+        return min(index, len(self) - 1)
+
+    def key_frame_seconds_for(self, seconds: float) -> float:
+        """Timestamp to :meth:`Demuxer.seek` to in order to reach ``seconds``:
+        that of the last :term:`keyframe` which isn't after it.
+
+        This is what makes a seek *exact*. FFmpeg resolves a seek against decode
+        timestamps, so on a file whose keyframes are reordered, seeking to the
+        target itself can land on a keyframe that is displayed after it, leaving
+        the frames in between unreachable
+        (https://trac.ffmpeg.org/ticket/11137). Seeking to a keyframe's own
+        timestamp lands on that keyframe, and the target is then reached by
+        decoding forward from there.
+
+        To reach a frame *index* rather than a timestamp, pass that frame's
+        timestamp: ``key_frame_seconds_for(pts_seconds[i])``.
+        """
+        # Same search as get_key_frame_index_for_pts_using_scanned_index()
+        # (SingleStreamDecoder.cpp): upper_bound minus one, i.e. the last
+        # keyframe at or before the target, and -1 when there is none.
+        position = (
+            int(torch.searchsorted(self._key_frame_seconds, seconds, right=True)) - 1
+        )
+        if position < 0:
+            # No keyframe at or before the target: the one it decodes from was
+            # trimmed away by an edit list, so it isn't in this index. Aim at
+            # the start of the stream and let FFmpeg find it, which is what
+            # exact mode does when that search returns -1.
+            return float(self.pts_seconds[0])
+        return float(self._key_frame_seconds[position])
+
+    def _to_seconds(self, value: Tensor) -> Tensor:
+        # pts_to_seconds() (FFMPEGCommon.cpp), and it has to stay bit-for-bit
+        # identical to it: float64 is C++ `double`, and the multiplication comes
+        # before the division on both sides. Timestamps from a StreamIndex are
+        # compared against, and fed back into, values the C++ produced.
+        return value.to(torch.float64) * self._time_base_num / self._time_base_den
+
+    @cached_property
+    def _end_seconds(self) -> Tensor:
+        return self._to_seconds(self._pts + self._duration)
+
+    @cached_property
+    def _key_frame_seconds(self) -> Tensor:
+        return self.pts_seconds[self.key_frame_indices]
 
 
 class Demuxer:
@@ -65,12 +194,39 @@ class Demuxer:
         handle, is_eof = _blocks_demuxer_next_packet(self._handle)
         return None if is_eof else Packet(handle)
 
-    # TODO_API_BREAKDOWN FEAT P1: this is VideoDecoder's "approximate"
-    # seek mode (with get_frame_played_at() only). Do we want to offer an
-    # "exact" one? It needs a presentation-order keyframe index, i.e. a scan of
-    # the whole file, which a user would have to opt into (a Demuxer.scan()?).
     def seek(self, seconds: float) -> None:
+        """Move the demuxer to ``seconds``.
+
+        A decoder can only start on a :term:`keyframe`, so this lands on the
+        keyframe at or before the target and the first frames that come out
+        usually precede it. The seek also invalidates the frames the decoder is
+        holding on to, so the :class:`PacketDecoder` must be ``reset()``.
+        """
         _blocks_demuxer_seek(self._handle, float(seconds))
+
+    def scan(self) -> StreamIndex:
+        """Demux the entire stream, without decoding it, and return its
+        :class:`StreamIndex`.
+
+        This reads the whole file, and it is the only way to know the stream's
+        exact frame count, timestamps and :term:`keyframe` positions: the
+        container header can be wrong about all of them.
+
+        The index always covers the entire stream, wherever the demuxer
+        currently is, and the demuxer is left back at the start - so a
+        :class:`PacketDecoder` built from it must be ``reset()``, as after a
+        ``seek()``. Nothing is cached: calling this twice scans twice.
+        """
+        pts, duration, is_key_frame, time_base_num, time_base_den = (
+            _blocks_demuxer_scan(self._handle)
+        )
+        return StreamIndex(
+            is_key_frame=is_key_frame,
+            _pts=pts,
+            _duration=duration,
+            _time_base_num=time_base_num,
+            _time_base_den=time_base_den,
+        )
 
     def __iter__(self):
         while True:

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -4771,6 +4771,175 @@ class TestBlocks:
         with pytest.raises(RuntimeError, match="has been drained"):
             decoder.decode(packet)
 
+    # ===== scanning =====
+
+    @pytest.mark.parametrize(
+        "video",
+        (*_ALL_VIDEOS, TEST_SRC_2_720P_MPEG4, TEST_SRC_2_720P_VP9),
+    )
+    def test_scan_matches_video_decoder_index(self, video):
+        # A scan is the same pass over the file that seek_mode="exact" makes at
+        # construction, so the index has to agree with VideoDecoder on
+        # everything the pass produces: how many frames there are, when each of
+        # them is displayed and for how long, and which ones are keyframes.
+        index = Demuxer(video.path).scan()
+        video_decoder = VideoDecoder(video.path, seek_mode="exact")
+        frames = video_decoder.get_all_frames()
+
+        assert len(index) == video_decoder.metadata.num_frames
+        torch.testing.assert_close(
+            index.pts_seconds, frames.pts_seconds, atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            index.duration_seconds, frames.duration_seconds, atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            index.key_frame_indices,
+            video_decoder._get_key_frame_indices(),
+            atol=0,
+            rtol=0,
+        )
+        assert index.begin_stream_seconds == video_decoder.metadata.begin_stream_seconds
+        assert index.end_stream_seconds == video_decoder.metadata.end_stream_seconds
+        assert index.average_fps == video_decoder.metadata.average_fps
+
+    @pytest.mark.parametrize(
+        "video",
+        (
+            NASA_VIDEO,
+            H265_VIDEO,
+            TEST_SRC_2_720P_MPEG4,
+            # The only asset that leaves gaps between its frames: one tick,
+            # after every third frame.
+            TEST_SRC_2_720P_VP9,
+        ),
+    )
+    def test_index_at_matches_video_decoder(self, video):
+        # index_at() looks up which frame is on screen at a timestamp;
+        # get_frame_played_at() decodes to find that same frame. They must
+        # agree.
+        index = Demuxer(video.path).scan()
+        video_decoder = VideoDecoder(video.path, seek_mode="exact")
+
+        for i in range(len(index) - 1):  # -1: each frame needs its successor
+            frame_start = float(index.pts_seconds[i])
+            frame_end = frame_start + float(index.duration_seconds[i])
+            next_frame_start = float(index.pts_seconds[i + 1])
+
+            targets = {
+                "inside the frame": frame_start + (frame_end - frame_start) / 4,
+                "first instant": frame_start,
+                # The boundary itself where the frames touch, a moment when
+                # nothing is on screen where they don't.
+                "just after the end": (frame_end + next_frame_start) / 2,
+            }
+            for description, seconds in targets.items():
+                expected = video_decoder.get_frame_played_at(seconds).pts_seconds
+                got = float(index.pts_seconds[index.index_at(seconds)])
+                assert got == expected, f"frame {i}, {description} ({seconds}s)"
+
+    def test_scan_skips_discarded_packets(self):
+        # This file's mp4 edit list flags its first packets - including the
+        # first keyframe - as AV_PKT_FLAG_DISCARD. They're demuxed but never
+        # become frames, so counting packets would put the index out of step
+        # with both the decoder and VideoDecoder.
+        video = DISCARD_FIRST_KEYFRAME_VIDEO
+        index = Demuxer(video.path).scan()
+
+        assert len(list(Demuxer(video.path))) == 30  # number of packets
+        assert len(index) == 25  # number of frames
+        assert VideoDecoder(video.path, seek_mode="exact").metadata.num_frames == 25
+
+    @pytest.mark.parametrize("video", (NASA_VIDEO, H265_VIDEO, TEST_SRC_2_720P_MPEG4))
+    def test_key_frame_seconds_for(self, video):
+        # It must return the last keyframe that isn't after the target, with no
+        # keyframe left in between.
+        index = Demuxer(video.path).scan()
+        key_frame_seconds = index.pts_seconds[index.key_frame_indices].tolist()
+
+        for i in range(len(index)):
+            start = float(index.pts_seconds[i])
+            for seconds in (start, start + float(index.duration_seconds[i]) / 2):
+                got = index.key_frame_seconds_for(seconds)
+                assert got <= seconds
+                assert [k for k in key_frame_seconds if got < k <= seconds] == []
+
+        for k in key_frame_seconds:
+            assert index.key_frame_seconds_for(k) == k
+
+    def test_key_frame_seconds_for_when_the_keyframe_was_trimmed(self):
+        # This file's first frames decode from a keyframe that the mp4 edit
+        # list flagged for discard, so it isn't in the index at all and there's
+        # nothing to point at. Fall back to the start of the stream, which is
+        # where FFmpeg goes looking for it anyway.
+        index = Demuxer(DISCARD_FIRST_KEYFRAME_VIDEO.path).scan()
+        pts_seconds = index.pts_seconds
+
+        assert index.key_frame_indices.tolist() == [5, 15]
+        for i in range(5):
+            # pts_seconds[0] isn't a key frame but it's the first frame, so it's the best we can do.
+            assert index.key_frame_seconds_for(pts_seconds[i]) == pts_seconds[0]
+        for i in range(5, 15):
+            assert index.key_frame_seconds_for(pts_seconds[i]) == pts_seconds[5]
+
+    @pytest.mark.parametrize("video", (NASA_VIDEO, H265_VIDEO, TEST_SRC_2_720P_MPEG4))
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_scan_seek_matches_video_decoder_exact(self, video, device):
+        # What the scan is for. Snapping the target back to the preceding
+        # keyframe before seeking is the entire difference between
+        # VideoDecoder's two seek modes for a timestamp lookup, so doing it
+        # here makes the blocks reproduce the exact one - including on
+        # H265_VIDEO, where a plain seek lands past the target
+        # (test_seek_to_non_keyframe_can_land_past_target) and this must not.
+        index = Demuxer(video.path).scan()
+
+        num_targets = 10
+
+        for i in range(0, len(index), max(1, len(index) // num_targets)):
+            # Aim at the middle of a frame, so that no target lands on a frame
+            # boundary where the two sides could round differently.
+            seconds = float(index.pts_seconds[i] + index.duration_seconds[i] / 2)
+            target_pts = float(index.pts_seconds[index.index_at(seconds)])
+            seek_to = index.key_frame_seconds_for(seconds)
+
+            # A fresh VideoDecoder per target: it skips the seek when the
+            # target is just ahead of the last frame it decoded, which would
+            # hide the very behaviour we're comparing against.
+            expected = VideoDecoder(
+                video.path, seek_mode="exact", device=device
+            ).get_frame_played_at(seconds)
+
+            blocks = self._make_blocks(video.path, device)
+            frames = self._frames_after_seek(blocks, seek_to)
+            got = next(frame for frame in frames if frame.pts_seconds >= target_pts)
+
+            assert got.pts_seconds == expected.pts_seconds
+            assert_frames_equal(got.data, expected.data)
+
+    @pytest.mark.parametrize("video", (NASA_VIDEO, H265_VIDEO, TEST_SRC_2_720P_MPEG4))
+    @pytest.mark.parametrize("device", _block_devices())
+    def test_scan_leaves_demuxer_at_the_start(self, video, device):
+        # A scan reads the file all the way to the end and then rewinds, so a
+        # pipeline built on that same demuxer still decodes the whole stream -
+        # and a scan started from somewhere else gives the very same index.
+        demuxer = Demuxer(video.path)
+        index = demuxer.scan()
+
+        decoder = PacketDecoder(demuxer, device=device)
+        converter = ColorConverter(device=device)
+        frames = list(
+            self._convert(converter, self._decode(decoder, self._demux(demuxer)))
+        )
+
+        assert len(frames) == len(index)
+        for frame, expected_pts in zip(frames, index.pts_seconds):
+            assert frame.pts_seconds == expected_pts
+
+        demuxer.seek(index.end_stream_seconds / 2)
+        torch.testing.assert_close(
+            demuxer.scan().pts_seconds, index.pts_seconds, atol=0, rtol=0
+        )
+
     # ===== source kinds =====
 
     @pytest.mark.parametrize("make_source", _BLOCKS_SOURCES)


### PR DESCRIPTION
Returns a StreamIndex which can then be used to reproduce the behavior of 'exact' seek mode, know where the keyframes are, etc.