### PR TITLE
Add AudioDemuxer to the Blocks API

### DIFF
--- a/benchmarks/bench_blocks.py
+++ b/benchmarks/bench_blocks.py
@@ -15,7 +15,7 @@ import psutil
 import torch
 
 from torchcodec.decoders import VideoDecoder
-from torchcodec.decoders._blocks import ColorConverter, Demuxer, PacketDecoder
+from torchcodec.decoders._blocks import ColorConverter, PacketDecoder, VideoDemuxer
 
 # Kept minimal on purpose; the filename is derived from exactly these.
 _DURATION_S = 10
@@ -112,7 +112,7 @@ def _consume(frames):
 
 
 def _decode_sequential(path, device="cpu"):
-    demuxer = Demuxer(path)
+    demuxer = VideoDemuxer(path)
     decoder = PacketDecoder(demuxer, device=device)
     converter = ColorConverter(device=device)
     _consume(_convert(converter, _decode(decoder, _demux(demuxer))))
@@ -120,7 +120,7 @@ def _decode_sequential(path, device="cpu"):
 
 def _decode_prefetch_frames(path, device="cpu"):
     # [demux + decode] on one thread || [color-convert] on another.
-    demuxer = Demuxer(path)
+    demuxer = VideoDemuxer(path)
     decoder = PacketDecoder(demuxer, device=device)
     converter = ColorConverter(device=device)
     frames = prefetch(_decode(decoder, _demux(demuxer)))
@@ -129,7 +129,7 @@ def _decode_prefetch_frames(path, device="cpu"):
 
 def _decode_prefetch_packets(path, device="cpu"):
     # [demux] on one thread || [decode + color-convert] on another.
-    demuxer = Demuxer(path)
+    demuxer = VideoDemuxer(path)
     decoder = PacketDecoder(demuxer, device=device)
     converter = ColorConverter(device=device)
     packets = prefetch(_demux(demuxer))
@@ -138,7 +138,7 @@ def _decode_prefetch_packets(path, device="cpu"):
 
 def _decode_prefetch_packets_and_frames(path, device="cpu"):
     # [demux] || [decode] || [color-convert], each on its own thread.
-    demuxer = Demuxer(path)
+    demuxer = VideoDemuxer(path)
     decoder = PacketDecoder(demuxer, device=device)
     converter = ColorConverter(device=device)
     packets = prefetch(_demux(demuxer))

--- a/examples/decoding/blocks.py
+++ b/examples/decoding/blocks.py
@@ -21,7 +21,7 @@ stages separately:
 
 .. code-block::
 
-   Demuxer  ->  PacketDecoder  ->  ColorConverter
+   VideoDemuxer  ->  PacketDecoder  ->  ColorConverter
     Packet         RawFrame          RGB Frame
 
 The blocks are passive: they never create threads, and they release the GIL.
@@ -67,9 +67,9 @@ subprocess.run(
 # decoding then runs on NVDEC and the color conversion on the GPU, and the
 # frames never leave the device. Demuxing always happens on the CPU. Left
 # unspecified, ``device`` is the current default device.
-from torchcodec.decoders._blocks import ColorConverter, Demuxer, PacketDecoder
+from torchcodec.decoders._blocks import ColorConverter, VideoDemuxer, PacketDecoder
 
-demuxer = Demuxer(video_path)
+demuxer = VideoDemuxer(video_path)
 packet_decoder = PacketDecoder(demuxer, device=device)
 color_converter = ColorConverter(device=device)
 
@@ -133,7 +133,7 @@ def prefetch(upstream, buffer_size=8):
 
 def sequential():
     # demux -> decode -> color-convert, all on the calling thread.
-    demuxer = Demuxer(video_path)
+    demuxer = VideoDemuxer(video_path)
     packet_decoder = PacketDecoder(demuxer, device=device)
     color_converter = ColorConverter(device=device)
     return color_convert(color_converter, decode(packet_decoder, demux(demuxer)))
@@ -141,7 +141,7 @@ def sequential():
 
 def convert_on_own_thread():
     # [demux + decode] on one thread || [color-convert] on another.
-    demuxer = Demuxer(video_path)
+    demuxer = VideoDemuxer(video_path)
     packet_decoder = PacketDecoder(demuxer, device=device)
     color_converter = ColorConverter(device=device)
     raw_frames = prefetch(decode(packet_decoder, demux(demuxer)))
@@ -152,7 +152,7 @@ def demux_on_own_thread():
     # [demux] on one thread || [decode + color-convert] on another. This is the
     # natural split on CUDA: demuxing is CPU and I/O work, while decoding and
     # color conversion both happen on the GPU, so they belong together.
-    demuxer = Demuxer(video_path)
+    demuxer = VideoDemuxer(video_path)
     packet_decoder = PacketDecoder(demuxer, device=device)
     color_converter = ColorConverter(device=device)
     packets = prefetch(demux(demuxer))
@@ -173,14 +173,14 @@ for pipeline in (sequential, convert_on_own_thread, demux_on_own_thread):
 # Seeking
 # -------
 #
-# ``Demuxer.seek()`` moves the demuxer to a timestamp. A decoder can only start
+# ``VideoDemuxer.seek()`` moves the demuxer to a timestamp. A decoder can only start
 # on a keyframe, so the seek lands on the keyframe at or before the target, and
 # the first frames that come out usually precede it: keep decoding forward and
 # drop them until you reach the timestamp you asked for.
 #
 # The seek also invalidates the frames the decoder is holding on to, so the
 # ``PacketDecoder`` must be ``reset()``.
-demuxer = Demuxer(video_path)
+demuxer = VideoDemuxer(video_path)
 packet_decoder = PacketDecoder(demuxer, device=device)
 color_converter = ColorConverter(device=device)
 
@@ -205,12 +205,12 @@ print(f"asked for {seconds}s, landed on {landed_on.pts_seconds:.3f}s, "
 # Scanning
 # --------
 #
-# ``Demuxer.scan()`` demuxes the whole stream once, without decoding anything,
+# ``VideoDemuxer.scan()`` demuxes the whole stream once, without decoding anything,
 # and returns a ``StreamIndex``: one entry per frame, in presentation order.
 # This is the only way to know a stream's exact frame count, timestamps and
 # keyframe positions - a container header can be wrong about all of them. It
 # costs one pass over the file, and it leaves the demuxer back at the start.
-demuxer = Demuxer(video_path)
+demuxer = VideoDemuxer(video_path)
 index = demuxer.scan()
 packet_decoder = PacketDecoder(demuxer, device=device)
 color_converter = ColorConverter(device=device)
@@ -280,7 +280,7 @@ print(f"frame {i} at {target.pts_seconds:.3f}s")
 #
 # Color conversion is optional. A ``RawFrame`` can hand out the decoder's own
 # planes as tensor views, with no copy and no conversion.
-demuxer = Demuxer(video_path)
+demuxer = VideoDemuxer(video_path)
 packet_decoder = PacketDecoder(demuxer, device=device)
 raw_frame = next(decode(packet_decoder, demux(demuxer)))
 
@@ -352,7 +352,7 @@ subprocess.run(
     capture_output=True,  # x265 logs its banner to stderr no matter what
 )
 
-hdr_demuxer = Demuxer(hdr_video_path)
+hdr_demuxer = VideoDemuxer(hdr_video_path)
 hdr_packet_decoder = PacketDecoder(hdr_demuxer, device=device)
 hdr_raw = next(decode(hdr_packet_decoder, demux(hdr_demuxer)))
 
@@ -412,7 +412,7 @@ ffmpeg.wait()
 # %%
 # The blocks just stream it, and we stop whenever we want:
 ffmpeg = start_live_stream()
-demuxer = Demuxer(fifo_path)
+demuxer = VideoDemuxer(fifo_path)
 packet_decoder = PacketDecoder(demuxer, device=device)
 color_converter = ColorConverter(device=device)
 

--- a/src/torchcodec/_core/Demuxer.cpp
+++ b/src/torchcodec/_core/Demuxer.cpp
@@ -46,9 +46,19 @@ int read_next_packet(
   return AVSUCCESS;
 }
 
+namespace {
+// "video" / "audio", for error messages.
+const char* printable(AVMediaType media_type) {
+  const char* name = av_get_media_type_string(media_type);
+  return name == nullptr ? "unknown" : name;
+}
+} // namespace
+
 Demuxer::Demuxer(
     const std::string& file_path,
-    std::optional<int> stream_index) {
+    std::optional<int> stream_index,
+    AVMediaType media_type)
+    : media_type_(media_type) {
   set_ffmpeg_log_level();
 
   AVFormatContext* raw_context = nullptr;
@@ -66,8 +76,10 @@ Demuxer::Demuxer(
 
 Demuxer::Demuxer(
     std::unique_ptr<AVIOContextHolder> avio_context_holder,
-    std::optional<int> stream_index)
-    : avio_context_holder_(std::move(avio_context_holder)) {
+    std::optional<int> stream_index,
+    AVMediaType media_type)
+    : avio_context_holder_(std::move(avio_context_holder)),
+      media_type_(media_type) {
   set_ffmpeg_log_level();
 
   STD_TORCH_CHECK(avio_context_holder_ != nullptr, "Context holder is null");
@@ -104,16 +116,17 @@ void Demuxer::validate_requested_stream(int stream_index) {
       num_streams - 1,
       "].");
 
-  AVMediaType media_type =
+  AVMediaType stream_media_type =
       format_context_->streams[stream_index]->codecpar->codec_type;
-  const char* media_type_name = av_get_media_type_string(media_type);
   STD_TORCH_CHECK(
-      media_type == AVMEDIA_TYPE_VIDEO,
+      stream_media_type == media_type_,
       "The stream at index ",
       stream_index,
-      " is not a video stream, it is of type '",
-      media_type_name == nullptr ? "unknown" : media_type_name,
-      "'. Only video streams can be demuxed.");
+      " is not a ",
+      printable(media_type_),
+      " stream, it is of type '",
+      printable(stream_media_type),
+      "'.");
 }
 
 void Demuxer::select_stream(std::optional<int> stream_index) {
@@ -129,15 +142,16 @@ void Demuxer::select_stream(std::optional<int> stream_index) {
 
   active_stream_index_ = av_find_best_stream(
       format_context_.get(),
-      AVMEDIA_TYPE_VIDEO,
+      media_type_,
       stream_index.value_or(-1),
       /*related_stream=*/-1,
       /*decoder_ret=*/nullptr,
       /*flags=*/0);
   STD_TORCH_CHECK(
       active_stream_index_ >= 0,
-      "No valid video stream found in input file. Only video streams are "
-      "supported: audio streams cannot be demuxed.");
+      "No valid ",
+      printable(media_type_),
+      " stream found in input file.");
   stream_ = format_context_->streams[active_stream_index_];
 
   // We only need packets from the active stream, so tell FFmpeg to discard the

--- a/src/torchcodec/_core/Demuxer.h
+++ b/src/torchcodec/_core/Demuxer.h
@@ -41,17 +41,20 @@ struct StreamIndex {
   AVRational time_base;
 };
 
-// Demux building block: owns an AVFormatContext, selects one video stream, and
-// yields its (compressed) packets. Does no decoding. Not thread-safe.
+// Demux building block: owns an AVFormatContext, selects one stream of the
+// requested media type, and yields its (compressed) packets. Does no decoding.
+// Not thread-safe.
 class FORCE_PUBLIC_VISIBILITY Demuxer {
  public:
   explicit Demuxer(
       const std::string& file_path,
-      std::optional<int> stream_index = std::nullopt);
+      std::optional<int> stream_index = std::nullopt,
+      AVMediaType media_type = AVMEDIA_TYPE_VIDEO);
 
   explicit Demuxer(
       std::unique_ptr<AVIOContextHolder> avio_context_holder,
-      std::optional<int> stream_index = std::nullopt);
+      std::optional<int> stream_index = std::nullopt,
+      AVMediaType media_type = AVMEDIA_TYPE_VIDEO);
 
   // Returns the next packet for the active stream as a freshly-allocated
   // packet, or a null packet at end of stream.
@@ -72,6 +75,10 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
     return active_stream_index_;
   }
 
+  AVMediaType media_type() const {
+    return media_type_;
+  }
+
   const UniqueDecodingAVFormatContext& format_context() const {
     return format_context_;
   }
@@ -86,6 +93,7 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   UniqueDecodingAVFormatContext format_context_;
   int active_stream_index_ = -1;
   AVStream* stream_ = nullptr;
+  AVMediaType media_type_ = AVMEDIA_TYPE_VIDEO;
   AutoAVPacket auto_packet_;
 };
 

--- a/src/torchcodec/_core/_decoder_utils.py
+++ b/src/torchcodec/_core/_decoder_utils.py
@@ -77,24 +77,25 @@ def create_demuxer(
     *,
     source: str | Path | io.RawIOBase | io.BufferedReader | bytes | Tensor,
     stream_index: int | None = None,
+    media_type: str = "video",
 ) -> Tensor:
     load_core_libraries()
     if isinstance(source, str):
-        return _blocks_create_demuxer_from_file(source, stream_index)
+        return _blocks_create_demuxer_from_file(source, stream_index, media_type)
     elif isinstance(source, Path):
-        return _blocks_create_demuxer_from_file(str(source), stream_index)
+        return _blocks_create_demuxer_from_file(str(source), stream_index, media_type)
     elif isinstance(source, bytes):
-        return _blocks_create_demuxer_from_bytes(source, stream_index)
+        return _blocks_create_demuxer_from_bytes(source, stream_index, media_type)
     elif isinstance(source, Tensor):
-        return _blocks_create_demuxer_from_tensor(source, stream_index)
+        return _blocks_create_demuxer_from_tensor(source, stream_index, media_type)
     elif isinstance(source, (io.RawIOBase, io.BufferedReader)):
-        return _blocks_create_demuxer_from_file_like(source, stream_index)
+        return _blocks_create_demuxer_from_file_like(source, stream_index, media_type)
     elif isinstance(source, io.TextIOBase):
         raise TypeError(
             "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
         )
     elif hasattr(source, "read") and hasattr(source, "seek"):
-        return _blocks_create_demuxer_from_file_like(source, stream_index)
+        return _blocks_create_demuxer_from_file_like(source, stream_index, media_type)
 
     raise TypeError(
         f"Unknown source type: {type(source)}. "

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -210,15 +210,19 @@ def create_from_file_like(
 
 
 def _blocks_create_demuxer_from_bytes(
-    video_bytes: bytes, stream_index: int | None = None
+    video_bytes: bytes,
+    stream_index: int | None = None,
+    media_type: str = "video",
 ) -> torch.Tensor:
     return _blocks_create_demuxer_from_tensor(
-        _bytes_to_tensor(video_bytes), stream_index
+        _bytes_to_tensor(video_bytes), stream_index, media_type
     )
 
 
 def _blocks_create_demuxer_from_file_like(
-    file_like: io.RawIOBase | io.BufferedReader, stream_index: int | None = None
+    file_like: io.RawIOBase | io.BufferedReader,
+    stream_index: int | None = None,
+    media_type: str = "video",
 ) -> torch.Tensor:
     assert _pybind_ops is not None
     return _blocks_create_demuxer_from_file_like_context(
@@ -226,6 +230,7 @@ def _blocks_create_demuxer_from_file_like(
             file_like, False  # False means not for writing
         ),
         stream_index,
+        media_type,
     )
 
 

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -74,11 +74,11 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def(
       "get_frames_by_pts(Tensor(a!) decoder, *, Tensor timestamps) -> (Tensor, Tensor, Tensor)");
   m.def(
-      "_blocks_create_demuxer_from_file(str filename, int? stream_index=None) -> Tensor");
+      "_blocks_create_demuxer_from_file(str filename, int? stream_index=None, str media_type=\"video\") -> Tensor");
   m.def(
-      "_blocks_create_demuxer_from_tensor(Tensor video_tensor, int? stream_index=None) -> Tensor");
+      "_blocks_create_demuxer_from_tensor(Tensor video_tensor, int? stream_index=None, str media_type=\"video\") -> Tensor");
   m.def(
-      "_blocks_create_demuxer_from_file_like(int file_like_context, int? stream_index=None) -> Tensor");
+      "_blocks_create_demuxer_from_file_like(int file_like_context, int? stream_index=None, str media_type=\"video\") -> Tensor");
   m.def("_blocks_demuxer_next_packet(Tensor(a!) demuxer) -> (Tensor, bool)");
   m.def("_blocks_demuxer_seek(Tensor(a!) demuxer, float seconds) -> ()");
   m.def(
@@ -809,17 +809,31 @@ std::optional<int> to_optional_int(std::optional<int64_t> value) {
   return static_cast<int>(value.value());
 }
 
+AVMediaType parse_media_type(const std::string& media_type) {
+  if (media_type == "video") {
+    return AVMEDIA_TYPE_VIDEO;
+  }
+  STD_TORCH_CHECK(
+      media_type == "audio",
+      "Invalid media_type: '",
+      media_type,
+      "'. Expected 'video' or 'audio'.");
+  return AVMEDIA_TYPE_AUDIO;
+}
+
 torch::stable::Tensor _blocks_create_demuxer_from_file(
     std::string filename,
-    std::optional<int64_t> stream_index) {
-  auto demuxer =
-      std::make_unique<Demuxer>(filename, to_optional_int(stream_index));
+    std::optional<int64_t> stream_index,
+    std::string media_type) {
+  auto demuxer = std::make_unique<Demuxer>(
+      filename, to_optional_int(stream_index), parse_media_type(media_type));
   return wrap_pointer_to_tensor<Demuxer>(std::move(demuxer));
 }
 
 torch::stable::Tensor _blocks_create_demuxer_from_tensor(
     const torch::stable::Tensor& video_tensor,
-    std::optional<int64_t> stream_index) {
+    std::optional<int64_t> stream_index,
+    std::string media_type) {
   STD_TORCH_CHECK(
       video_tensor.is_contiguous(), "video_tensor must be contiguous");
   STD_TORCH_CHECK(
@@ -829,13 +843,16 @@ torch::stable::Tensor _blocks_create_demuxer_from_tensor(
   auto avio_context_holder = std::make_unique<AVIOContextHolder>(
       std::make_unique<TensorReadIO>(video_tensor), /*is_for_writing=*/false);
   auto demuxer = std::make_unique<Demuxer>(
-      std::move(avio_context_holder), to_optional_int(stream_index));
+      std::move(avio_context_holder),
+      to_optional_int(stream_index),
+      parse_media_type(media_type));
   return wrap_pointer_to_tensor<Demuxer>(std::move(demuxer));
 }
 
 torch::stable::Tensor _blocks_create_demuxer_from_file_like(
     int64_t file_like_context,
-    std::optional<int64_t> stream_index) {
+    std::optional<int64_t> stream_index,
+    std::string media_type) {
   auto file_like_context_ptr =
       reinterpret_cast<IOInterface*>(file_like_context);
   STD_TORCH_CHECK(
@@ -846,7 +863,9 @@ torch::stable::Tensor _blocks_create_demuxer_from_file_like(
       std::unique_ptr<IOInterface>(file_like_context_ptr),
       /*is_for_writing=*/false);
   auto demuxer = std::make_unique<Demuxer>(
-      std::move(avio_context_holder), to_optional_int(stream_index));
+      std::move(avio_context_holder),
+      to_optional_int(stream_index),
+      parse_media_type(media_type));
   return wrap_pointer_to_tensor<Demuxer>(std::move(demuxer));
 }
 

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -6,22 +6,27 @@
 
 """Private, experimental building-block decode API.
 
-Exposes the three decode stages -- :class:`Demuxer`, :class:`PacketDecoder`,
-:class:`ColorConverter` -- as passive, composable, GIL-releasing units, so a
-caller can build its own (threaded) decode pipeline and tune how the stages
-overlap. The blocks do no threading themselves.
+Exposes the three decode stages -- :class:`VideoDemuxer`,
+:class:`PacketDecoder`, :class:`ColorConverter` -- as passive, composable,
+GIL-releasing units, so a caller can build its own (threaded) decode pipeline
+and tune how the stages overlap. The blocks do no threading themselves.
+
+:class:`AudioDemuxer` is the audio counterpart of :class:`VideoDemuxer`;
+:class:`PacketDecoder` is shared, since decoding is the same operation either
+way.
 
 This is experimental and private; the API may change. See
 API_breakdown_claude_plan.md for the design and rationale.
 """
 
 from ._color_converter import ColorConverter
-from ._demuxer import Demuxer, StreamIndex
+from ._demuxer import AudioDemuxer, StreamIndex, VideoDemuxer
 from ._frame import Packet, RawFrame
 from ._packet_decoder import PacketDecoder
 
 __all__ = [
-    "Demuxer",
+    "VideoDemuxer",
+    "AudioDemuxer",
     "PacketDecoder",
     "ColorConverter",
     "Packet",
@@ -30,5 +35,7 @@ __all__ = [
 ]
 
 # TODO_API_BREAKDOWN FEAT P1 we probably need a way to expose the *header*
-# metadata - something that would avoid using VideoDecoder? Demuxer.scan()
-# covers the content-derived half of that.
+# metadata - something that would avoid using VideoDecoder? VideoDemuxer.scan()
+# covers the content-derived half of that. Audio makes this more pressing:
+# there is no scan() there, so sample_rate / num_channels / sample_format are
+# only reachable through AudioDecoder today.

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -261,10 +261,6 @@ class VideoDemuxer(_BaseDemuxer):
         )
 
 
-# TODO_API_BREAKDOWN FEAT P1 no scan() here: StreamIndex is video-shaped
-# (keyframes, frame indices, fps), and audio has none of those notions. What an
-# audio scan should return - exact duration, total sample count - is part of the
-# StreamIndex redesign above.
 class AudioDemuxer(_BaseDemuxer):
     """Demux building block: opens a container and yields the compressed
     :class:`Packet`\\ s for one audio stream. Does no decoding.

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -34,7 +34,7 @@ from ._frame import Packet
 # audio!
 @dataclass
 class StreamIndex:
-    """The content of a video stream, as returned by :meth:`Demuxer.scan`.
+    """The content of a video stream, as returned by :meth:`VideoDemuxer.scan`.
 
     One entry per frame, in presentation order. Everything here is derived from
     the packets of the stream rather than from the container header, so the
@@ -110,7 +110,7 @@ class StreamIndex:
         return min(index, len(self) - 1)
 
     def key_frame_seconds_for(self, seconds: float) -> float:
-        """Timestamp to :meth:`Demuxer.seek` to in order to reach ``seconds``:
+        """Timestamp to :meth:`VideoDemuxer.seek` to in order to reach ``seconds``:
         that of the last :term:`keyframe` which isn't after it.
 
         This is what makes a seek *exact*. FFmpeg resolves a seek against decode
@@ -154,17 +154,66 @@ class StreamIndex:
         return self.pts_seconds[self.key_frame_indices]
 
 
-class Demuxer:
+class _BaseDemuxer:
+    """Shared machinery for :class:`VideoDemuxer` and :class:`AudioDemuxer`.
+
+    Subclasses set ``_media_type``, which is what the stream selection is done
+    against.
+    """
+
+    _media_type: str
+
+    def __init__(
+        self,
+        source: str | Path | bytes | Tensor | io.RawIOBase | io.BufferedReader,
+        *,
+        stream_index: int | None = None,
+    ):
+        self._handle = create_demuxer(
+            source=source, stream_index=stream_index, media_type=self._media_type
+        )
+
+    def next_packet(self) -> Packet | None:
+        """Return the next :class:`Packet`, or ``None`` at end of stream."""
+        handle, is_eof = _blocks_demuxer_next_packet(self._handle)
+        return None if is_eof else Packet(handle)
+
+    def seek(self, seconds: float) -> None:
+        """Move the demuxer to ``seconds``.
+
+        A seek invalidates whatever the decoder is holding on to, so the
+        :class:`PacketDecoder` must be ``reset()`` afterwards.
+
+        Where you land, and what comes out first, depends on the medium. For
+        video, a decoder can only start on a :term:`keyframe`, so this lands on
+        the keyframe at or before the target and the first frames that come out
+        usually precede it. Audio has no keyframe to land on: the codec's
+        overlap-add state is lost, so a lossy stream's first few frames after a
+        seek are subtly wrong - plausible, but not the samples that whole-file
+        decoding would give - until it re-primes. Decoding a margin before the
+        target and discarding it is the caller's responsibility.
+        """
+        _blocks_demuxer_seek(self._handle, float(seconds))
+
+    def __iter__(self):
+        while True:
+            packet = self.next_packet()
+            if packet is None:
+                return
+            yield packet
+
+
+class VideoDemuxer(_BaseDemuxer):
     """Demux building block: opens a container and yields the compressed
-    :class:`Packet`\\ s for one (video) stream. Does no decoding.
+    :class:`Packet`\\ s for one video stream. Does no decoding.
 
     This block is passive (it does no threading of its own) and is *not*
-    thread-safe: use one ``Demuxer`` per thread. It streams from the start of
-    the file, or from wherever :meth:`seek` left it.
+    thread-safe: use one ``VideoDemuxer`` per thread. It streams from the start
+    of the file, or from wherever :meth:`seek` left it.
 
-    A :class:`Demuxer` also carries the stream configuration used to build a
-    :class:`PacketDecoder` and :class:`ColorConverter`, so those are constructed from
-    a demuxer and no extra container is opened.
+    A :class:`VideoDemuxer` also carries the stream configuration used to build a
+    :class:`PacketDecoder`, so that is constructed from a demuxer and no extra
+    container is opened.
 
     Args:
         source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the video:
@@ -180,33 +229,12 @@ class Demuxer:
 
         stream_index (int, optional): Specifies which stream in the video to
             demux packets from. Note that this index is absolute across all
-            media types. It must refer to a video stream: audio streams aren't
-            supported, and requesting one raises an error. If left unspecified,
-            then the :term:`best stream` is used.
+            media types. It must refer to a video stream; use
+            :class:`AudioDemuxer` for audio. If left unspecified, then the
+            :term:`best stream` is used.
     """
 
-    def __init__(
-        self,
-        source: str | Path | bytes | Tensor | io.RawIOBase | io.BufferedReader,
-        *,
-        stream_index: int | None = None,
-    ):
-        self._handle = create_demuxer(source=source, stream_index=stream_index)
-
-    def next_packet(self) -> Packet | None:
-        """Return the next :class:`Packet`, or ``None`` at end of stream."""
-        handle, is_eof = _blocks_demuxer_next_packet(self._handle)
-        return None if is_eof else Packet(handle)
-
-    def seek(self, seconds: float) -> None:
-        """Move the demuxer to ``seconds``.
-
-        A decoder can only start on a :term:`keyframe`, so this lands on the
-        keyframe at or before the target and the first frames that come out
-        usually precede it. The seek also invalidates the frames the decoder is
-        holding on to, so the :class:`PacketDecoder` must be ``reset()``.
-        """
-        _blocks_demuxer_seek(self._handle, float(seconds))
+    _media_type = "video"
 
     def scan(self) -> StreamIndex:
         """Demux the entire stream, without decoding it, and return its
@@ -232,9 +260,43 @@ class Demuxer:
             _time_base_den=time_base_den,
         )
 
-    def __iter__(self):
-        while True:
-            packet = self.next_packet()
-            if packet is None:
-                return
-            yield packet
+
+# TODO_API_BREAKDOWN FEAT P1 no scan() here: StreamIndex is video-shaped
+# (keyframes, frame indices, fps), and audio has none of those notions. What an
+# audio scan should return - exact duration, total sample count - is part of the
+# StreamIndex redesign above.
+class AudioDemuxer(_BaseDemuxer):
+    """Demux building block: opens a container and yields the compressed
+    :class:`Packet`\\ s for one audio stream. Does no decoding.
+
+    This block is passive (it does no threading of its own) and is *not*
+    thread-safe: use one ``AudioDemuxer`` per thread. It streams from the start
+    of the file, or from wherever :meth:`seek` left it.
+
+    An :class:`AudioDemuxer` also carries the stream configuration used to build
+    a :class:`PacketDecoder`, so that is constructed from a demuxer and no extra
+    container is opened.
+
+    Unlike :class:`VideoDemuxer` there is no ``scan()``: a :class:`StreamIndex`
+    describes keyframes and frame indices, and audio has neither.
+
+    Args:
+        source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the audio:
+
+            - If ``str``: a local path or a URL to an audio or video file.
+            - If ``Pathlib.path``: a path to a local audio or video file.
+            - If ``bytes`` object or ``torch.Tensor``: the raw encoded data.
+            - If file-like object: we read data from the object on demand. The object must
+              expose the methods `read(self, size: int) -> bytes` and
+              `seek(self, offset: int, whence: int) -> int`. Note that every
+              read has to re-acquire the GIL, so a file-like source doesn't
+              parallelize with the rest of a pipeline as well as the others do.
+
+        stream_index (int, optional): Specifies which stream in the file to
+            demux packets from. Note that this index is absolute across all
+            media types. It must refer to an audio stream; use
+            :class:`VideoDemuxer` for video. If left unspecified, then the
+            :term:`best stream` is used.
+    """
+
+    _media_type = "audio"

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -28,7 +28,7 @@ class _Metadata(NamedTuple):
 class Packet:
     """Opaque, thread-movable handle to a demuxed (compressed) packet.
 
-    Produced by :class:`Demuxer`, consumed by :class:`PacketDecoder`. It wraps a raw
+    Produced by :class:`VideoDemuxer`, consumed by :class:`PacketDecoder`. It wraps a raw
     pointer, so it is only valid within the process that created it (it cannot
     cross a process boundary).
     """

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -17,7 +17,7 @@ from torchcodec._core.ops import (
 )
 
 from .._decoder_utils import convert_device_to_str
-from ._demuxer import Demuxer
+from ._demuxer import VideoDemuxer
 from ._frame import Packet, RawFrame
 
 
@@ -28,7 +28,7 @@ class PacketDecoder:
     """Decode building block: turns compressed :class:`Packet`\\ s into decoded
     (YUV) :class:`RawFrame`\\ s.
 
-    Built from a :class:`Demuxer` (for its codec parameters) and stateful (it
+    Built from a :class:`VideoDemuxer` (for its codec parameters) and stateful (it
     holds the codec's reference-frame buffer). Passive and *not* thread-safe:
     use one ``PacketDecoder`` per thread. FFmpeg's internal codec thread count
     is kept at 1 for now (not exposed); parallelism comes from composing blocks
@@ -38,7 +38,7 @@ class PacketDecoder:
     which means the current default device (see ``torch.set_default_device``).
     """
 
-    def __init__(self, demuxer: Demuxer, device: str | torch.device | None = None):
+    def __init__(self, demuxer: VideoDemuxer, device: str | torch.device | None = None):
         self._handle = _blocks_create_packet_decoder(
             demuxer._handle, num_threads=1, device=convert_device_to_str(device)
         )

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -42,11 +42,12 @@ from torchcodec.decoders import (
     WavDecoder,
 )
 from torchcodec.decoders._blocks import (
+    AudioDemuxer,
     ColorConverter,
-    Demuxer,
     Packet,
     PacketDecoder,
     RawFrame,
+    VideoDemuxer,
 )
 from torchcodec.decoders._decoder_utils import _get_cuda_backend
 from torchcodec.decoders._image_decoders import _source_to_tensor
@@ -3634,7 +3635,7 @@ class TestBlocks:
 
     @pytest.mark.parametrize("device", _block_devices())
     def test_block_output_types(self, device):
-        # Demuxer yields Packets, PacketDecoder yields RawFrames, and
+        # VideoDemuxer yields Packets, PacketDecoder yields RawFrames, and
         # ColorConverter yields Frames with the expected shape/dtype.
         demuxer, decoder, converter = self._make_blocks(NASA_VIDEO.path, device)
 
@@ -3708,7 +3709,7 @@ class TestBlocks:
 
     @staticmethod
     def _make_blocks(path, device):
-        demuxer = Demuxer(path)
+        demuxer = VideoDemuxer(path)
         decoder = PacketDecoder(demuxer, device=device)
         converter = ColorConverter(device=device)
         return demuxer, decoder, converter
@@ -3972,7 +3973,7 @@ class TestBlocks:
 
         def assert_first_frame_is_on_default_device():
             # Note the absence of any device parameter.
-            demuxer = Demuxer(NASA_VIDEO.path)
+            demuxer = VideoDemuxer(NASA_VIDEO.path)
             decoder = PacketDecoder(demuxer)
             converter = ColorConverter()
             decoded = next(self._decode(decoder, self._demux(demuxer)))
@@ -4429,7 +4430,7 @@ class TestBlocks:
         # that scoping is the point. get_frame_played_at() is the only
         # VideoDecoder API that seeks straight to the timestamp it was given:
         # it turns `seconds` into a pts and hands that to FFmpeg, which is the
-        # same two steps Demuxer.seek() takes, so the match is structural
+        # same two steps VideoDemuxer.seek() takes, so the match is structural
         # rather than a property of these files. Every other API goes through
         # a frame index, which approximate mode derives from the header's
         # average fps and converts back into a pts - a round trip nothing in
@@ -4476,7 +4477,7 @@ class TestBlocks:
         keyframe_index = video_decoder._get_key_frame_indices()[1]
         seconds = video_decoder.get_frame_at(keyframe_index).pts_seconds
 
-        demuxer = Demuxer(NASA_VIDEO.path)
+        demuxer = VideoDemuxer(NASA_VIDEO.path)
         decoder = PacketDecoder(demuxer, device=device)
         num_decoded = 0
         for packet in demuxer:  # decode a bit, so frames pile up in the codec
@@ -4741,7 +4742,7 @@ class TestBlocks:
             # fmt: on
         )
         try:
-            demuxer = Demuxer(fifo_path)
+            demuxer = VideoDemuxer(fifo_path)
             decoder = PacketDecoder(demuxer)
             num_decoded = 0
             for packet in demuxer:  # make sure the stream is really flowing
@@ -4762,7 +4763,7 @@ class TestBlocks:
         # Draining ends the stream as far as the codec is concerned, and it
         # ignores anything sent afterwards. Rather than silently decoding
         # nothing, say so.
-        demuxer = Demuxer(H265_VIDEO.path)
+        demuxer = VideoDemuxer(H265_VIDEO.path)
         decoder = PacketDecoder(demuxer, device=device)
         packet = demuxer.next_packet()
         decoder.decode(packet)
@@ -4782,7 +4783,7 @@ class TestBlocks:
         # construction, so the index has to agree with VideoDecoder on
         # everything the pass produces: how many frames there are, when each of
         # them is displayed and for how long, and which ones are keyframes.
-        index = Demuxer(video.path).scan()
+        index = VideoDemuxer(video.path).scan()
         video_decoder = VideoDecoder(video.path, seek_mode="exact")
         frames = video_decoder.get_all_frames()
 
@@ -4818,7 +4819,7 @@ class TestBlocks:
         # index_at() looks up which frame is on screen at a timestamp;
         # get_frame_played_at() decodes to find that same frame. They must
         # agree.
-        index = Demuxer(video.path).scan()
+        index = VideoDemuxer(video.path).scan()
         video_decoder = VideoDecoder(video.path, seek_mode="exact")
 
         for i in range(len(index) - 1):  # -1: each frame needs its successor
@@ -4844,9 +4845,9 @@ class TestBlocks:
         # become frames, so counting packets would put the index out of step
         # with both the decoder and VideoDecoder.
         video = DISCARD_FIRST_KEYFRAME_VIDEO
-        index = Demuxer(video.path).scan()
+        index = VideoDemuxer(video.path).scan()
 
-        assert len(list(Demuxer(video.path))) == 30  # number of packets
+        assert len(list(VideoDemuxer(video.path))) == 30  # number of packets
         assert len(index) == 25  # number of frames
         assert VideoDecoder(video.path, seek_mode="exact").metadata.num_frames == 25
 
@@ -4854,7 +4855,7 @@ class TestBlocks:
     def test_key_frame_seconds_for(self, video):
         # It must return the last keyframe that isn't after the target, with no
         # keyframe left in between.
-        index = Demuxer(video.path).scan()
+        index = VideoDemuxer(video.path).scan()
         key_frame_seconds = index.pts_seconds[index.key_frame_indices].tolist()
 
         for i in range(len(index)):
@@ -4872,7 +4873,7 @@ class TestBlocks:
         # list flagged for discard, so it isn't in the index at all and there's
         # nothing to point at. Fall back to the start of the stream, which is
         # where FFmpeg goes looking for it anyway.
-        index = Demuxer(DISCARD_FIRST_KEYFRAME_VIDEO.path).scan()
+        index = VideoDemuxer(DISCARD_FIRST_KEYFRAME_VIDEO.path).scan()
         pts_seconds = index.pts_seconds
 
         assert index.key_frame_indices.tolist() == [5, 15]
@@ -4891,7 +4892,7 @@ class TestBlocks:
         # here makes the blocks reproduce the exact one - including on
         # H265_VIDEO, where a plain seek lands past the target
         # (test_seek_to_non_keyframe_can_land_past_target) and this must not.
-        index = Demuxer(video.path).scan()
+        index = VideoDemuxer(video.path).scan()
 
         num_targets = 10
 
@@ -4922,7 +4923,7 @@ class TestBlocks:
         # A scan reads the file all the way to the end and then rewinds, so a
         # pipeline built on that same demuxer still decodes the whole stream -
         # and a scan started from somewhere else gives the very same index.
-        demuxer = Demuxer(video.path)
+        demuxer = VideoDemuxer(video.path)
         index = demuxer.scan()
 
         decoder = PacketDecoder(demuxer, device=device)
@@ -4978,7 +4979,7 @@ class TestBlocks:
     def test_stream_index(self, stream_index):
         # nasa_13013.mp4 has two video streams, 0 and 3, of different sizes,
         # and 3 is the best one, i.e. the one used when nothing is requested.
-        demuxer = Demuxer(NASA_VIDEO.path, stream_index=stream_index)
+        demuxer = VideoDemuxer(NASA_VIDEO.path, stream_index=stream_index)
         decoder = PacketDecoder(demuxer)
         converter = ColorConverter()
         got = [
@@ -4997,30 +4998,84 @@ class TestBlocks:
     @pytest.mark.parametrize("stream_index", (1, 4))  # the mp4's aac streams
     def test_audio_stream_index_raises(self, stream_index):
         with pytest.raises(RuntimeError, match="is not a video stream.*'audio'"):
-            Demuxer(NASA_VIDEO.path, stream_index=stream_index)
+            VideoDemuxer(NASA_VIDEO.path, stream_index=stream_index)
 
     def test_audio_only_file_raises(self):
         with pytest.raises(RuntimeError, match="No valid video stream found"):
-            Demuxer(NASA_AUDIO_MP3.path)
+            VideoDemuxer(NASA_AUDIO_MP3.path)
+
+    @pytest.mark.parametrize("stream_index", (0, 3))  # the mp4's video streams
+    def test_video_stream_index_raises_on_audio_demuxer(self, stream_index):
+        with pytest.raises(RuntimeError, match="is not a audio stream.*'video'"):
+            AudioDemuxer(NASA_VIDEO.path, stream_index=stream_index)
+
+    def test_video_only_file_raises_on_audio_demuxer(self):
+        with pytest.raises(RuntimeError, match="No valid audio stream found"):
+            AudioDemuxer(H265_VIDEO.path)
 
     def test_non_video_stream_index_raises(self):
         # Stream 2 of the mp4 is a subtitle stream.
         with pytest.raises(RuntimeError, match="is not a video stream.*'subtitle'"):
-            Demuxer(NASA_VIDEO.path, stream_index=2)
+            VideoDemuxer(NASA_VIDEO.path, stream_index=2)
+
+    # ===== AudioDemuxer =====
+
+    @pytest.mark.parametrize(
+        "asset", (NASA_AUDIO_MP3, NASA_AUDIO, SINE_MONO_S32, SINE_16_CHANNEL_S16)
+    )
+    def test_audio_demuxer_yields_packets(self, asset):
+        packets = list(AudioDemuxer(asset.path))
+        assert len(packets) > 0
+        assert all(isinstance(packet, Packet) for packet in packets)
+
+    def test_audio_demuxer_picks_the_audio_stream_of_a_video_file(self):
+        # nasa_13013.mp4 has video streams (0, 3) and aac streams (1, 4). The
+        # audio and video demuxers see different, non-empty packet streams.
+        num_audio_packets = len(list(AudioDemuxer(NASA_VIDEO.path)))
+        num_video_packets = len(list(VideoDemuxer(NASA_VIDEO.path)))
+        assert num_audio_packets > 0
+        assert num_video_packets > 0
+        assert num_audio_packets != num_video_packets
+
+    @pytest.mark.parametrize("stream_index", (None, 1, 4))
+    def test_audio_demuxer_stream_index(self, stream_index):
+        assert len(list(AudioDemuxer(NASA_VIDEO.path, stream_index=stream_index))) > 0
+
+    @pytest.mark.parametrize("make_source", _BLOCKS_SOURCES)
+    def test_audio_demuxer_source_kinds(self, make_source):
+        # Every source kind demuxes the very same packets as the path does.
+        expected = len(list(AudioDemuxer(NASA_AUDIO_MP3.path)))
+        assert len(list(AudioDemuxer(make_source(NASA_AUDIO_MP3.path)))) == expected
+
+    def test_audio_demuxer_seek(self):
+        # Seeking past the start leaves fewer packets to demux. We don't assert
+        # anything about *which* ones: audio has no keyframe to land on, so
+        # where a seek lands is the demuxer's business, not something we pin.
+        num_packets_from_start = len(list(AudioDemuxer(NASA_AUDIO_MP3.path)))
+
+        demuxer = AudioDemuxer(NASA_AUDIO_MP3.path)
+        demuxer.seek(NASA_AUDIO_MP3.duration_seconds / 2)
+        num_packets_after_seek = len(list(demuxer))
+
+        assert 0 < num_packets_after_seek < num_packets_from_start
+
+    def test_audio_demuxer_has_no_scan(self):
+        # See the TODO in _demuxer.py: StreamIndex is video-shaped.
+        assert not hasattr(AudioDemuxer(NASA_AUDIO_MP3.path), "scan")
 
     @pytest.mark.parametrize("stream_index", (-1, 6, 1000))
     def test_invalid_stream_index_raises(self, stream_index):
         with pytest.raises(RuntimeError, match="is not a valid stream"):
-            Demuxer(NASA_VIDEO.path, stream_index=stream_index)
+            VideoDemuxer(NASA_VIDEO.path, stream_index=stream_index)
 
     def test_bad_source_type_raises(self):
         with pytest.raises(TypeError, match="Unknown source type"):
-            Demuxer(123)
+            VideoDemuxer(123)
 
         # user mistakenly forgets to specify binary reading when creating a
         # file-like object from open()
         with pytest.raises(TypeError, match="binary reading?"):
-            Demuxer(open(NASA_VIDEO.path))
+            VideoDemuxer(open(NASA_VIDEO.path))
 
 
 # Small helpers to avoid having to always specify the same skip marks and decode_fn

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -5048,9 +5048,7 @@ class TestBlocks:
         assert len(list(AudioDemuxer(make_source(NASA_AUDIO_MP3.path)))) == expected
 
     def test_audio_demuxer_seek(self):
-        # Seeking past the start leaves fewer packets to demux. We don't assert
-        # anything about *which* ones: audio has no keyframe to land on, so
-        # where a seek lands is the demuxer's business, not something we pin.
+        # Seeking past the start leaves fewer packets to demux.
         num_packets_from_start = len(list(AudioDemuxer(NASA_AUDIO_MP3.path)))
 
         demuxer = AudioDemuxer(NASA_AUDIO_MP3.path)
@@ -5058,10 +5056,6 @@ class TestBlocks:
         num_packets_after_seek = len(list(demuxer))
 
         assert 0 < num_packets_after_seek < num_packets_from_start
-
-    def test_audio_demuxer_has_no_scan(self):
-        # See the TODO in _demuxer.py: StreamIndex is video-shaped.
-        assert not hasattr(AudioDemuxer(NASA_AUDIO_MP3.path), "scan")
 
     @pytest.mark.parametrize("stream_index", (-1, 6, 1000))
     def test_invalid_stream_index_raises(self, stream_index):


### PR DESCRIPTION
Renames the blocks Demuxer to VideoDemuxer and adds an AudioDemuxer next to
it. The C++ Demuxer stays a single class: only stream selection is
media-specific, so it grows an AVMediaType argument and the three
_blocks_create_demuxer_from_* ops grow a media_type kwarg.

AudioDemuxer has no scan(): StreamIndex describes keyframes and frame
indices, and audio has neither. seek() is shared, with the caveat that audio
has no keyframe to land on documented on the base class.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>