### PR TITLE
Reject out-of-range negative sampling starts

### DIFF
--- a/src/torchcodec/samplers/_index_based.py
+++ b/src/torchcodec/samplers/_index_based.py
@@ -31,6 +31,12 @@ def _validate_sampling_range_index_based(
     sampling_range_end,
     num_frames_in_video,
 ):
+    if sampling_range_start < -num_frames_in_video:
+        raise ValueError(
+            f"sampling_range_start ({sampling_range_start}) must be greater than "
+            f"or equal to {-num_frames_in_video}."
+        )
+
     if sampling_range_start < 0:
         sampling_range_start = num_frames_in_video + sampling_range_start
 

--- a/test/test_samplers.py
+++ b/test/test_samplers.py
@@ -536,6 +536,20 @@ def test_index_based_samplers_errors(sampler):
     ):
         sampler(decoder, sampling_range_start=-100, sampling_range_end=-100)
 
+    sampling_range_start = -len(decoder) - 1
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            f"sampling_range_start ({sampling_range_start}) must be greater than "
+            f"or equal to {-len(decoder)}"
+        ),
+    ):
+        sampler(
+            decoder,
+            sampling_range_start=sampling_range_start,
+            sampling_range_end=-len(decoder),
+        )
+
     with pytest.raises(
         ValueError, match="We determined that sampling_range_end should"
     ):


### PR DESCRIPTION
## Summary

Validate the lower bound of sampling_range_start before normalizing negative indices.

## Root cause

Values below -len(decoder) were normalized to a still-negative frame index and could reach the index-based sampler/decoder path instead of being rejected as invalid input. The fix rejects those values while preserving the valid boundary at -len(decoder).

## Verification

- Added a regression case to the shared index-based sampler error suite, covering both public index-based samplers.
- Passed py_compile for both changed Python files.
- Passed the configured pre-commit hooks for both changed files.
- Passed git diff --check.
- A focused AST-level invariant check fails on the pristine source and passes with the patch, including the exact lower-bound and boundary cases.
- Passed the full sampler test module with Python 3.13: 51 passed. The local wheel supplied the native video decoder; unavailable image decoders are not exercised by this module.
- Scoped mypy reaches five existing errors in unrelated imported modules; the changed file adds no reported error.

## Additional context

No open issue or pull request was found for this exact lower-bound case at the time of preparation. The validation follows the existing Python-style negative-index boundary: -len(decoder) is valid and smaller values are rejected before normalization.

AI assistance was used to prepare this draft. The submitter is responsible for reviewing, understanding, and defending every changed line. No CLA or other legal agreement has been accepted on the submitter's behalf.
