### PR TITLE
fix: add missing num_threads param to decode_avif disabled stub

### DIFF
--- a/src/torchcodec/_core/DecodeAvif.cpp
+++ b/src/torchcodec/_core/DecodeAvif.cpp
@@ -19,7 +19,8 @@ namespace facebook::torchcodec {
 torch::stable::Tensor decode_avif(
     [[maybe_unused]] const torch::stable::Tensor& input,
     [[maybe_unused]] int64_t mode,
-    [[maybe_unused]] int64_t output_dtype) {
+    [[maybe_unused]] int64_t output_dtype,
+    [[maybe_unused]] int64_t num_threads) {
   STD_TORCH_CHECK(
       false,
       "decode_avif: torchcodec was not compiled with libavif support. Rebuild "


### PR DESCRIPTION
Fixes #1670

## Summary

The `#if !TORCHCODEC_ENABLE_AVIF` stub for `decode_avif` in `DecodeAvif.cpp` is missing the `num_threads` parameter that the header (`DecodeAvif.h`) declares and the enabled implementation uses. This causes `libtorchcodec_image.so` to have an undefined symbol when built with `TORCHCODEC_BUILD_AVIF=0`, which makes `import torchcodec` fail at runtime.

The fix adds the missing `[[maybe_unused]] int64_t num_threads` parameter to the disabled stub so its signature matches the header declaration.

## Test plan

- Build with `TORCHCODEC_BUILD_AVIF=0` and verify `import torchcodec` succeeds
- Verify `decode_avif()` raises the expected "not compiled with libavif support" error instead of a symbol resolution crash