### PR TITLE
Rename StreamIndex to FrameIndex and suffix its content-derived scalars

### DIFF
--- a/examples/decoding/blocks.py
+++ b/examples/decoding/blocks.py
@@ -209,17 +209,22 @@ print(f"asked for {seconds}s, landed on {landed_on.pts_seconds:.3f}s, "
 # --------
 #
 # ``VideoDemuxer.scan()`` demuxes the whole stream once, without decoding anything,
-# and returns a ``StreamIndex``: one entry per frame, in presentation order.
+# and returns a ``FrameIndex``: one entry per frame, in presentation order.
 # This is the only way to know a stream's exact frame count, timestamps and
 # keyframe positions - a container header can be wrong about all of them. It
 # costs one pass over the file, and it leaves the demuxer back at the start.
+#
+# The ``_from_content`` suffix marks the values the header also claims to know:
+# it is there so that a call site says which of the two sources it trusts.
 demuxer = VideoDemuxer(video_path)
 index = demuxer.scan()
 packet_decoder = VideoPacketDecoder(demuxer, device=device)
 color_converter = ColorConverter(device=device)
 
-print(f"{len(index)} frames at {index.average_fps} fps, "
-      f"from {index.begin_stream_seconds}s to {index.end_stream_seconds}s")
+print(f"{index.num_frames_from_content} frames at "
+      f"{index.average_fps_from_content} fps, "
+      f"from {index.begin_stream_seconds_from_content}s "
+      f"to {index.end_stream_seconds_from_content}s")
 
 # %%
 # The index is also what gives the blocks frame *indices*, which they otherwise

--- a/src/torchcodec/_core/Demuxer.cpp
+++ b/src/torchcodec/_core/Demuxer.cpp
@@ -187,7 +187,7 @@ struct ScannedPacket {
 };
 } // namespace
 
-StreamIndex Demuxer::scan() {
+FrameIndex Demuxer::scan() {
   std::vector<ScannedPacket> packets;
   if (stream_->nb_frames > 0) {
     packets.reserve(static_cast<size_t>(stream_->nb_frames));
@@ -227,7 +227,7 @@ StreamIndex Demuxer::scan() {
   seek(0);
 
   auto num_frames = static_cast<int64_t>(packets.size());
-  StreamIndex index{
+  FrameIndex index{
       torch::stable::empty({num_frames}, kStableInt64),
       torch::stable::empty({num_frames}, kStableInt64),
       torch::stable::empty({num_frames}, kStableBool),

--- a/src/torchcodec/_core/Demuxer.h
+++ b/src/torchcodec/_core/Demuxer.h
@@ -34,7 +34,7 @@ std::string get_seek_error_message(
 // The frames of the active stream, in presentation order: three parallel
 // tensors of length N, plus the time base `pts` and `duration` are expressed
 // in.
-struct StreamIndex {
+struct FrameIndex {
   torch::stable::Tensor pts; // int64 [N]
   torch::stable::Tensor duration; // int64 [N]
   torch::stable::Tensor is_key_frame; // bool [N]
@@ -65,7 +65,7 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   // Demuxes the entire stream, without decoding, and returns one entry per
   // frame sorted by pts. Leaves the demuxer back at the start of the stream,
   // and keeps no state of its own.
-  StreamIndex scan();
+  FrameIndex scan();
 
   AVStream* active_stream() const {
     return stream_;

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -905,7 +905,7 @@ using OpsScanOutput = std::tuple<
     int64_t>;
 
 OpsScanOutput _blocks_demuxer_scan(torch::stable::Tensor& demuxer) {
-  StreamIndex index = unwrap_tensor_to_pointer<Demuxer>(demuxer)->scan();
+  FrameIndex index = unwrap_tensor_to_pointer<Demuxer>(demuxer)->scan();
   return std::make_tuple(
       index.pts,
       index.duration,

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -17,7 +17,7 @@ API_breakdown_claude_plan.md for the design and rationale.
 
 from ._audio_converter import AudioConverter
 from ._color_converter import ColorConverter
-from ._demuxer import AudioDemuxer, StreamIndex, VideoDemuxer
+from ._demuxer import AudioDemuxer, FrameIndex, VideoDemuxer
 from ._frame import Packet, RawAudioSamples, RawFrame
 from ._packet_decoder import AudioPacketDecoder, VideoPacketDecoder
 
@@ -31,7 +31,7 @@ __all__ = [
     "Packet",
     "RawFrame",
     "RawAudioSamples",
-    "StreamIndex",
+    "FrameIndex",
 ]
 
 # TODO_API_BREAKDOWN FEAT P1 we probably need a way to expose the *header*

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -28,17 +28,19 @@ from ._frame import Packet
 # specific timestamps for sampling?
 
 
-# TODO_API_BREAKDOWN DESIGN P1: need to figure out the right API for this.
-# StreamIndex? the fields? The methods?
-# We'll have a big problem if/when we implement multi-stream demuxing - and
-# audio!
 @dataclass
-class StreamIndex:
+class FrameIndex:
     """The content of a video stream, as returned by :meth:`VideoDemuxer.scan`.
 
     One entry per frame, in presentation order. Everything here is derived from
     the packets of the stream rather than from the container header, so the
     values are exact.
+
+    The scalars that the header also claims to know carry a ``_from_content``
+    suffix, so that a call site says which source it trusts:
+    ``num_frames_from_content`` here against ``num_frames_from_header`` on the
+    stream's metadata. The per-frame arrays have no header counterpart and are
+    left unsuffixed.
 
     Timestamps are stored in the stream's own time base and converted to
     seconds on access, which is what makes those conversions exact: a frame's
@@ -61,6 +63,11 @@ class StreamIndex:
         """The number of frames in the stream."""
         return self.is_key_frame.shape[0]
 
+    @property
+    def num_frames_from_content(self) -> int:
+        """The number of frames in the stream."""
+        return len(self)
+
     @cached_property
     def pts_seconds(self) -> Tensor:
         """float64 ``[N]``, the presentation timestamp of each frame."""
@@ -77,12 +84,12 @@ class StreamIndex:
         return self.is_key_frame.nonzero().squeeze(1)
 
     @cached_property
-    def begin_stream_seconds(self) -> float:
+    def begin_stream_seconds_from_content(self) -> float:
         """Presentation timestamp of the first frame."""
         return float(self.pts_seconds[0])
 
     @cached_property
-    def end_stream_seconds(self) -> float:
+    def end_stream_seconds_from_content(self) -> float:
         """Timestamp at which the last frame stops being displayed."""
         # max(), not [-1]: durations vary, so the frame that finishes last
         # isn't necessarily the one that starts last. This is how
@@ -90,9 +97,12 @@ class StreamIndex:
         return float(self._end_seconds.max())
 
     @property
-    def average_fps(self) -> float:
+    def average_fps_from_content(self) -> float:
         """Average number of frames per second over the stream."""
-        return len(self) / (self.end_stream_seconds - self.begin_stream_seconds)
+        return len(self) / (
+            self.end_stream_seconds_from_content
+            - self.begin_stream_seconds_from_content
+        )
 
     def index_at(self, seconds: float) -> int:
         """Index of the frame that is being displayed at ``seconds``.
@@ -141,7 +151,7 @@ class StreamIndex:
     def _to_seconds(self, value: Tensor) -> Tensor:
         # pts_to_seconds() (FFMPEGCommon.cpp), and it has to stay bit-for-bit
         # identical to it: float64 is C++ `double`, and the multiplication comes
-        # before the division on both sides. Timestamps from a StreamIndex are
+        # before the division on both sides. Timestamps from a FrameIndex are
         # compared against, and fed back into, values the C++ produced.
         return value.to(torch.float64) * self._time_base_num / self._time_base_den
 
@@ -236,9 +246,9 @@ class VideoDemuxer(_BaseDemuxer):
 
     _media_type = "video"
 
-    def scan(self) -> StreamIndex:
+    def scan(self) -> FrameIndex:
         """Demux the entire stream, without decoding it, and return its
-        :class:`StreamIndex`.
+        :class:`FrameIndex`.
 
         This reads the whole file, and it is the only way to know the stream's
         exact frame count, timestamps and :term:`keyframe` positions: the
@@ -252,7 +262,7 @@ class VideoDemuxer(_BaseDemuxer):
         pts, duration, is_key_frame, time_base_num, time_base_den = (
             _blocks_demuxer_scan(self._handle)
         )
-        return StreamIndex(
+        return FrameIndex(
             is_key_frame=is_key_frame,
             _pts=pts,
             _duration=duration,
@@ -273,7 +283,7 @@ class AudioDemuxer(_BaseDemuxer):
     an :class:`AudioPacketDecoder`, so that is constructed from a demuxer and
     no extra container is opened.
 
-    Unlike :class:`VideoDemuxer` there is no ``scan()``: a :class:`StreamIndex`
+    Unlike :class:`VideoDemuxer` there is no ``scan()``: a :class:`FrameIndex`
     describes keyframes and frame indices, and audio has neither.
 
     Args:

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -119,6 +119,7 @@ class FrameIndex:
         index = int(torch.searchsorted(self._end_seconds, seconds, right=True))
         return min(index, len(self) - 1)
 
+    # TODO_API_BREAKDOWN DESIGN P1: Still kinda hate this name
     def key_frame_seconds_for(self, seconds: float) -> float:
         """Timestamp to :meth:`VideoDemuxer.seek` to in order to reach ``seconds``:
         that of the last :term:`keyframe` which isn't after it.

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -4802,6 +4802,7 @@ class TestBlocks:
         frames = video_decoder.get_all_frames()
 
         assert len(index) == video_decoder.metadata.num_frames
+        assert index.num_frames_from_content == video_decoder.metadata.num_frames
         torch.testing.assert_close(
             index.pts_seconds, frames.pts_seconds, atol=0, rtol=0
         )
@@ -4814,9 +4815,15 @@ class TestBlocks:
             atol=0,
             rtol=0,
         )
-        assert index.begin_stream_seconds == video_decoder.metadata.begin_stream_seconds
-        assert index.end_stream_seconds == video_decoder.metadata.end_stream_seconds
-        assert index.average_fps == video_decoder.metadata.average_fps
+        assert (
+            index.begin_stream_seconds_from_content
+            == video_decoder.metadata.begin_stream_seconds
+        )
+        assert (
+            index.end_stream_seconds_from_content
+            == video_decoder.metadata.end_stream_seconds
+        )
+        assert index.average_fps_from_content == video_decoder.metadata.average_fps
 
     @pytest.mark.parametrize(
         "video",
@@ -4950,7 +4957,7 @@ class TestBlocks:
         for frame, expected_pts in zip(frames, index.pts_seconds):
             assert frame.pts_seconds == expected_pts
 
-        demuxer.seek(index.end_stream_seconds / 2)
+        demuxer.seek(index.end_stream_seconds_from_content / 2)
         torch.testing.assert_close(
             demuxer.scan().pts_seconds, index.pts_seconds, atol=0, rtol=0
         )


### PR DESCRIPTION
"Index" was doing three jobs at once: the scan result type, a stream's position in the container, and a frame's position in a stream. This was confusing, so `StreamIndex` is not `FrameIndex`: an index of frames.

Its scalars that the container header also claims to know now carry a `_from_content` suffix, matching the names already used on `VideoStreamMetadata`: `num_frames_from_content` (new, alongside __len__),  begin_stream_seconds_from_content`, `end_stream_seconds_from_content`, and `average_fps_from_content`. A call site now says which source it trusts.

The per-frame arrays keep their bare names. Also, there is deliberately no scalar `duration_seconds_from_content`: it would collide with the per-frame `duration_seconds` array. Callers can just subtract `end - begin` manually.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>