### PR TITLE
Signal end of stream with a packet, so a decode loop can drain itself

### DIFF
--- a/benchmarks/bench_blocks.py
+++ b/benchmarks/bench_blocks.py
@@ -66,8 +66,7 @@ def _demux(demuxer):
 
 def _decode(decoder, packets):
     for packet in packets:
-        yield from decoder.decode(packet)
-    yield from decoder.drain()
+        yield from decoder.drain() if packet.is_eof else decoder.decode(packet)
 
 
 def _convert(converter, frames):

--- a/examples/decoding/blocks.py
+++ b/examples/decoding/blocks.py
@@ -78,10 +78,12 @@ color_converter = ColorConverter(device=device)
 
 frames = []
 for packet in demuxer:
-    for raw_frame in packet_decoder.decode(packet):
+    # The demuxer signals the end of the stream with a packet that carries no
+    # data, and that is the cue to drain the frames the codec is still holding.
+    raw_frames = (packet_decoder.drain() if packet.is_eof
+                  else packet_decoder.decode(packet))
+    for raw_frame in raw_frames:
         frames.append(color_converter.convert(raw_frame))
-for raw_frame in packet_decoder.drain():
-    frames.append(color_converter.convert(raw_frame))
 
 print(f"{len(frames)} frames, {frames[0].data.shape = }, "
       f"{frames[0].pts_seconds = }, {frames[0].data.device = }")
@@ -104,8 +106,8 @@ def demux(demuxer):
 
 def decode(packet_decoder, packets):
     for packet in packets:
-        yield from packet_decoder.decode(packet)
-    yield from packet_decoder.drain()
+        yield from (packet_decoder.drain() if packet.is_eof
+                    else packet_decoder.decode(packet))
 
 
 def color_convert(color_converter, raw_frames):
@@ -490,8 +492,9 @@ audio_converter = AudioConverter(sample_rate=16_000, num_channels=1)
 
 chunks = []
 for packet in demuxer:
-    chunks += [audio_converter.convert(raw) for raw in packet_decoder.decode(packet)]
-chunks += [audio_converter.convert(raw) for raw in packet_decoder.drain()]
+    raw_samples = (packet_decoder.drain() if packet.is_eof
+                   else packet_decoder.decode(packet))
+    chunks += [audio_converter.convert(raw) for raw in raw_samples]
 chunks.append(audio_converter.drain())  # don't forget me
 
 samples = torch.cat([chunk.data for chunk in chunks], dim=1)

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -182,11 +182,33 @@ class _BaseDemuxer:
         self._handle = create_demuxer(
             source=source, stream_index=stream_index, media_type=self._media_type
         )
+        self._pending_eof: list[Packet] | None = None
+
+    def _eof_packets(self) -> list[Packet]:
+        """One end-of-stream marker per stream being followed."""
+        return [Packet(None, is_eof=True)]
 
     def next_packet(self) -> Packet | None:
-        """Return the next :class:`Packet`, or ``None`` at end of stream."""
-        handle, is_eof = _blocks_demuxer_next_packet(self._handle)
-        return None if is_eof else Packet(handle)
+        """Return the next :class:`Packet`, or ``None`` once there is nothing
+        left at all.
+
+        When the container is exhausted this first hands out one end-of-stream
+        marker per stream being followed - a :class:`Packet` whose ``is_eof`` is
+        set and which carries no data. Routing those to their decoder the same
+        way as any other packet is what lets a decode loop drain itself::
+
+            for packet in demuxer:
+                raws = decoder.drain() if packet.is_eof else decoder.decode(packet)
+
+        Note this is not an early warning: FFmpeg reports no per-stream end, so
+        every marker arrives together, once the whole container is done.
+        """
+        if self._pending_eof is None:
+            handle, is_eof = _blocks_demuxer_next_packet(self._handle)
+            if not is_eof:
+                return Packet(handle)
+            self._pending_eof = self._eof_packets()
+        return self._pending_eof.pop(0) if self._pending_eof else None
 
     def seek(self, seconds: float) -> None:
         """Move the demuxer to ``seconds``.
@@ -204,6 +226,9 @@ class _BaseDemuxer:
         target and discarding it is the caller's responsibility.
         """
         _blocks_demuxer_seek(self._handle, float(seconds))
+        # There are packets ahead of us again, so the end-of-stream markers this
+        # demuxer may already have handed out no longer apply.
+        self._pending_eof = None
 
     def __iter__(self):
         while True:
@@ -262,6 +287,8 @@ class VideoDemuxer(_BaseDemuxer):
         pts, duration, is_key_frame, time_base_num, time_base_den = (
             _blocks_demuxer_scan(self._handle)
         )
+        # A scan rewinds, so as after a seek there are packets ahead of us again.
+        self._pending_eof = None
         return FrameIndex(
             is_key_frame=is_key_frame,
             _pts=pts,

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -32,10 +32,17 @@ class Packet:
     Produced by :class:`VideoDemuxer`, consumed by :class:`VideoPacketDecoder`. It wraps a raw
     pointer, so it is only valid within the process that created it (it cannot
     cross a process boundary).
+
+    Attributes:
+        is_eof (bool): Whether this is an end-of-stream marker rather than a
+            packet. A demuxer emits one of these once its stream is exhausted;
+            it carries no data, and it is the cue to ``drain()`` the decoder
+            that stream feeds. See :meth:`VideoDemuxer.next_packet`.
     """
 
-    def __init__(self, handle: torch.Tensor):
+    def __init__(self, handle: torch.Tensor | None, *, is_eof: bool = False):
         self._handle = handle
+        self.is_eof = is_eof
 
 
 # TODO_API_BREAKDOWN DESIGN P1: API design - the public fields, the class name,

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -50,6 +50,12 @@ class _BasePacketDecoder(Generic[_Decoded]):
     def decode(self, packet: Packet) -> list[_Decoded]:
         """Send one packet and return whatever is now ready (possibly empty,
         e.g. while the codec buffers B-frames)."""
+        if packet.is_eof:
+            raise ValueError(
+                "This is an end-of-stream marker, not a packet: it carries no "
+                "data to decode. Call drain() instead, to get the frames the "
+                "codec is still holding on to."
+            )
         if self._drained:
             raise RuntimeError(
                 "This decoder has been drained, and a codec that has been told "

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3645,6 +3645,8 @@ class TestBlocks:
         num_packets = 0
         for packet in demuxer:
             assert isinstance(packet, Packet)
+            if packet.is_eof:
+                continue
             num_packets += 1
             for decoded in decoder.decode(packet):
                 assert isinstance(decoded, RawFrame)
@@ -3658,6 +3660,38 @@ class TestBlocks:
 
         assert num_packets > 0
 
+    @pytest.mark.parametrize("demuxer_class", (VideoDemuxer, AudioDemuxer))
+    def test_eof_marker(self, demuxer_class):
+        demuxer = demuxer_class(NASA_VIDEO.path)
+        packets = list(demuxer)
+
+        assert not any(packet.is_eof for packet in packets[:-1])
+        assert packets[-1].is_eof
+        # And once the markers are out, there is nothing left, for good.
+        assert demuxer.next_packet() is None
+        assert demuxer.next_packet() is None
+        assert list(demuxer) == []
+
+    def test_decoding_an_eof_marker_raises(self):
+        demuxer = VideoDemuxer(NASA_VIDEO.path)
+        decoder = VideoPacketDecoder(demuxer)
+        *_, eof = list(demuxer)
+
+        with pytest.raises(ValueError, match="end-of-stream marker"):
+            decoder.decode(eof)
+
+    def test_seeking_past_eof_resumes(self):
+        # A seek puts packets ahead of us again, so the demuxer that just said
+        # it was done has to start answering.
+        demuxer = VideoDemuxer(NASA_VIDEO.path)
+        assert list(demuxer)[-1].is_eof
+        assert demuxer.next_packet() is None
+
+        demuxer.seek(0)
+        packets = list(demuxer)
+        assert len(packets) > 1
+        assert packets[-1].is_eof
+
     # The three decode stages, each expressed as a generator that transforms an
     # iterator of inputs into an iterator of outputs. They compose directly (the
     # sequential pipeline is just convert(decode(demux()))), and a thread
@@ -3670,8 +3704,10 @@ class TestBlocks:
     @staticmethod
     def _decode(decoder, packets):
         for packet in packets:
-            yield from decoder.decode(packet)
-        yield from decoder.drain()
+            if packet.is_eof:
+                yield from decoder.drain()
+            else:
+                yield from decoder.decode(packet)
 
     @staticmethod
     def _convert(converter, frames):
@@ -4095,10 +4131,10 @@ class TestBlocks:
         def run(separate_stream):
             demuxer, decoder, _ = self._make_blocks(video, "cuda")
             reads = []
-            for packet in itertools.chain(demuxer, [None]):
+            for packet in demuxer:
                 with torch.cuda.stream(decode_stream):
                     decoded = (
-                        decoder.drain() if packet is None else decoder.decode(packet)
+                        decoder.drain() if packet.is_eof else decoder.decode(packet)
                     )
                 with torch.cuda.stream(
                     read_stream if separate_stream else decode_stream
@@ -4134,9 +4170,9 @@ class TestBlocks:
         convert_stream = torch.cuda.Stream()
 
         frames = []
-        for packet in itertools.chain(demuxer, [None]):
+        for packet in demuxer:
             with torch.cuda.stream(decode_stream):
-                decoded = decoder.drain() if packet is None else decoder.decode(packet)
+                decoded = decoder.drain() if packet.is_eof else decoder.decode(packet)
             with torch.cuda.stream(convert_stream):
                 while decoded:
                     torch.cuda._sleep(20_000_000)  # ~10ms
@@ -4334,12 +4370,11 @@ class TestBlocks:
         demuxer.seek(seconds)
         decoder.reset()
         for packet in demuxer:
-            for raw_frame in decoder.decode(packet):
+            # Seeking into the last GOP can leave the codec holding frames until
+            # it's told the stream ended.
+            raws = decoder.drain() if packet.is_eof else decoder.decode(packet)
+            for raw_frame in raws:
                 yield converter.convert(raw_frame)
-        # Seeking into the last GOP can leave the codec holding frames until
-        # it's told the stream ended.
-        for decoded_frame in decoder.drain():
-            yield converter.convert(decoded_frame)
 
     def _first_frame_after_seek(self, blocks, seconds):
         return next(self._frames_after_seek(blocks, seconds))
@@ -4868,7 +4903,8 @@ class TestBlocks:
         video = DISCARD_FIRST_KEYFRAME_VIDEO
         index = VideoDemuxer(video.path).scan()
 
-        assert len(list(VideoDemuxer(video.path))) == 30  # number of packets
+        packets = [p for p in VideoDemuxer(video.path) if not p.is_eof]
+        assert len(packets) == 30  # number of packets
         assert len(index) == 25  # number of frames
         assert VideoDecoder(video.path, seek_mode="exact").metadata.num_frames == 25
 
@@ -5089,8 +5125,7 @@ class TestBlocks:
             decoder.reset()
         chunks = []
         for packet in demuxer:
-            chunks += decoder.decode(packet)
-        chunks += decoder.drain()
+            chunks += decoder.drain() if packet.is_eof else decoder.decode(packet)
         return chunks
 
     @pytest.mark.parametrize(
@@ -5231,8 +5266,7 @@ class TestBlocks:
 
         chunks = []
         for packet in demuxer:
-            chunks += decoder.decode(packet)
-        chunks += decoder.drain()
+            chunks += decoder.drain() if packet.is_eof else decoder.decode(packet)
 
         assert len(chunks) > 0
         num_samples = sum(chunk.num_samples for chunk in chunks)
@@ -5252,8 +5286,7 @@ class TestBlocks:
             decoder.reset()
             converter.reset()
         for packet in demuxer:
-            raw_chunks += decoder.decode(packet)
-        raw_chunks += decoder.drain()
+            raw_chunks += decoder.drain() if packet.is_eof else decoder.decode(packet)
         if seek_seconds is not None:
             # The caller's pre-roll, see
             # test_audio_raw_samples_match_audio_decoder.
@@ -5408,8 +5441,8 @@ class TestBlocks:
             decoder = AudioPacketDecoder(demuxer)
             chunks = []
             for packet in demuxer:
-                chunks += [converter.convert(raw) for raw in decoder.decode(packet)]
-            chunks += [converter.convert(raw) for raw in decoder.drain()]
+                raws = decoder.drain() if packet.is_eof else decoder.decode(packet)
+                chunks += [converter.convert(raw) for raw in raws]
             chunks.append(converter.drain())
             return self._cat(chunks)
 
@@ -5470,8 +5503,8 @@ class TestBlocks:
 
         chunks = []
         for packet in demuxer:
-            chunks += [converter.convert(raw) for raw in decoder.decode(packet)]
-        chunks += [converter.convert(raw) for raw in decoder.drain()]
+            raws = decoder.drain() if packet.is_eof else decoder.decode(packet)
+            chunks += [converter.convert(raw) for raw in raws]
         chunks.append(converter.drain())
 
         samples = self._cat(chunks)


### PR DESCRIPTION
A demuxer used to just stop, leaving the caller to remember a drain() after
the loop. It now hands out one end-of-stream marker per stream it follows -
a Packet with is_eof set and no data - before it starts returning None:

    for packet in demuxer:
        raws = decoder.drain() if packet.is_eof else decoder.decode(packet)

The drain moves inside the loop, which is what makes it survive multi-stream
demuxing: with several decoders, the drain-after-the-loop shape has to name
each one, and forgetting one silently loses the tail of that stream. Routing
the marker like any other packet gets it right by construction. Two tests
were already hand-rolling this with itertools.chain(demuxer, [None]).

This is not an early warning. FFmpeg reports no per-stream end, so every
marker arrives together once the whole container is done.

A seek, or a scan, puts packets ahead of us again and clears the markers
already handed out. Feeding a marker to decode() raises rather than being
mistaken for an empty packet.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>