### PR TITLE
Let the C++ Demuxer follow several streams of one container

### DIFF
--- a/src/torchcodec/_core/Demuxer.cpp
+++ b/src/torchcodec/_core/Demuxer.cpp
@@ -32,18 +32,44 @@ std::string get_seek_error_message(
   return ss.str();
 }
 
-int read_next_packet(
+namespace {
+template <typename IsActive>
+int read_next_active_packet(
     AVFormatContext* format_context,
-    int active_stream_index,
-    ReferenceAVPacket& packet) {
+    ReferenceAVPacket& packet,
+    IsActive is_active) {
   int status = AVSUCCESS;
   do {
     status = av_read_frame(format_context, packet.get());
     if (status == AVERROR_EOF || status < AVSUCCESS) {
       return status;
     }
-  } while (packet->stream_index != active_stream_index);
+  } while (!is_active(packet->stream_index));
   return AVSUCCESS;
+}
+} // namespace
+
+int read_next_packet(
+    AVFormatContext* format_context,
+    int active_stream_index,
+    ReferenceAVPacket& packet) {
+  return read_next_active_packet(
+      format_context, packet, [active_stream_index](int stream_index) {
+        return stream_index == active_stream_index;
+      });
+}
+
+int read_next_packet(
+    AVFormatContext* format_context,
+    const std::vector<int>& active_stream_indices,
+    ReferenceAVPacket& packet) {
+  return read_next_active_packet(
+      format_context, packet, [&active_stream_indices](int stream_index) {
+        return std::find(
+                   active_stream_indices.begin(),
+                   active_stream_indices.end(),
+                   stream_index) != active_stream_indices.end();
+      });
 }
 
 namespace {
@@ -54,11 +80,7 @@ const char* printable(AVMediaType media_type) {
 }
 } // namespace
 
-Demuxer::Demuxer(
-    const std::string& file_path,
-    std::optional<int> stream_index,
-    AVMediaType media_type)
-    : media_type_(media_type) {
+Demuxer::Demuxer(const std::string& file_path) {
   set_ffmpeg_log_level();
 
   AVFormatContext* raw_context = nullptr;
@@ -71,15 +93,11 @@ Demuxer::Demuxer(
   STD_TORCH_CHECK(raw_context != nullptr, "Failed to allocate AVFormatContext");
   format_context_.reset(raw_context);
 
-  select_stream(stream_index);
+  find_stream_info();
 }
 
-Demuxer::Demuxer(
-    std::unique_ptr<AVIOContextHolder> avio_context_holder,
-    std::optional<int> stream_index,
-    AVMediaType media_type)
-    : avio_context_holder_(std::move(avio_context_holder)),
-      media_type_(media_type) {
+Demuxer::Demuxer(std::unique_ptr<AVIOContextHolder> avio_context_holder)
+    : avio_context_holder_(std::move(avio_context_holder)) {
   set_ffmpeg_log_level();
 
   STD_TORCH_CHECK(avio_context_holder_ != nullptr, "Context holder is null");
@@ -101,10 +119,28 @@ Demuxer::Demuxer(
   }
   format_context_.reset(raw_context);
 
-  select_stream(stream_index);
+  find_stream_info();
 }
 
-void Demuxer::validate_requested_stream(int stream_index) {
+void Demuxer::find_stream_info() {
+  int status = avformat_find_stream_info(format_context_.get(), nullptr);
+  STD_TORCH_CHECK(
+      status >= 0,
+      "Failed to find stream info: ",
+      get_ffmpeg_error_string_from_error_code(status));
+
+  // We only want packets from the streams we're asked to follow, so discard
+  // every stream until add_stream() says otherwise. Note av_read_frame() may
+  // still return some of them under certain conditions, which is why
+  // read_next_packet() also filters by stream index.
+  for (unsigned int i = 0; i < format_context_->nb_streams; ++i) {
+    format_context_->streams[i]->discard = AVDISCARD_ALL;
+  }
+}
+
+void Demuxer::validate_requested_stream(
+    int stream_index,
+    AVMediaType media_type) {
   int num_streams = static_cast<int>(format_context_->nb_streams);
   STD_TORCH_CHECK(
       stream_index >= 0 && stream_index < num_streams,
@@ -119,57 +155,91 @@ void Demuxer::validate_requested_stream(int stream_index) {
   AVMediaType stream_media_type =
       format_context_->streams[stream_index]->codecpar->codec_type;
   STD_TORCH_CHECK(
-      stream_media_type == media_type_,
+      stream_media_type == media_type,
       "The stream at index ",
       stream_index,
       " is not a ",
-      printable(media_type_),
+      printable(media_type),
       " stream, it is of type '",
       printable(stream_media_type),
       "'.");
 }
 
-void Demuxer::select_stream(std::optional<int> stream_index) {
-  int status = avformat_find_stream_info(format_context_.get(), nullptr);
+int Demuxer::add_stream(
+    std::optional<int> stream_index,
+    AVMediaType media_type) {
   STD_TORCH_CHECK(
-      status >= 0,
-      "Failed to find stream info: ",
-      get_ffmpeg_error_string_from_error_code(status));
+      !has_demuxed_,
+      "Streams must all be added before the first packet is demuxed: a stream "
+      "added now would start at wherever the container currently is, not at "
+      "the beginning.");
 
   if (stream_index.has_value()) {
-    validate_requested_stream(*stream_index);
+    validate_requested_stream(*stream_index, media_type);
   }
 
-  active_stream_index_ = av_find_best_stream(
+  int index = av_find_best_stream(
       format_context_.get(),
-      media_type_,
+      media_type,
       stream_index.value_or(-1),
       /*related_stream=*/-1,
       /*decoder_ret=*/nullptr,
       /*flags=*/0);
   STD_TORCH_CHECK(
-      active_stream_index_ >= 0,
+      index >= 0,
       "No valid ",
-      printable(media_type_),
+      printable(media_type),
       " stream found in input file.");
-  stream_ = format_context_->streams[active_stream_index_];
+  STD_TORCH_CHECK(
+      std::find(
+          active_stream_indices_.begin(),
+          active_stream_indices_.end(),
+          index) == active_stream_indices_.end(),
+      "The stream at index ",
+      index,
+      " is already being demuxed.");
 
-  // We only need packets from the active stream, so tell FFmpeg to discard the
-  // others. Note av_read_frame() may still return some of them under certain
-  // conditions, which is why read_next_packet() also filters by stream index.
-  for (unsigned int i = 0; i < format_context_->nb_streams; ++i) {
-    if (i != static_cast<unsigned int>(active_stream_index_)) {
-      format_context_->streams[i]->discard = AVDISCARD_ALL;
-    }
-  }
+  format_context_->streams[index]->discard = AVDISCARD_DEFAULT;
+  active_stream_indices_.push_back(index);
+  return index;
 }
 
-void Demuxer::seek(double seconds) {
-  int64_t desired_pts = seconds_to_closest_pts(seconds, stream_->time_base);
+int Demuxer::resolve_stream_index(std::optional<int> stream_index) const {
+  if (stream_index.has_value()) {
+    STD_TORCH_CHECK(
+        std::find(
+            active_stream_indices_.begin(),
+            active_stream_indices_.end(),
+            *stream_index) != active_stream_indices_.end(),
+        "The stream at index ",
+        *stream_index,
+        " is not being demuxed.");
+    return *stream_index;
+  }
+  STD_TORCH_CHECK(
+      active_stream_indices_.size() == 1,
+      "This demuxer follows ",
+      active_stream_indices_.size(),
+      " streams, so the stream index must be specified.");
+  return active_stream_indices_[0];
+}
+
+AVStream* Demuxer::get_reference_stream() const {
+  STD_TORCH_CHECK(
+      !active_stream_indices_.empty(),
+      "This demuxer isn't following any stream yet.");
+  return format_context_->streams[active_stream_indices_[0]];
+}
+
+void Demuxer::seek(double seconds, std::optional<int> stream_index) {
+  AVStream* reference = stream_index.has_value()
+      ? format_context_->streams[resolve_stream_index(stream_index)]
+      : get_reference_stream();
+  int64_t desired_pts = seconds_to_closest_pts(seconds, reference->time_base);
 
   int status = avformat_seek_file(
       format_context_.get(),
-      active_stream_index_,
+      reference->index,
       INT64_MIN,
       desired_pts,
       desired_pts,
@@ -187,18 +257,21 @@ struct ScannedPacket {
 };
 } // namespace
 
-FrameIndex Demuxer::scan() {
+FrameIndex Demuxer::scan(std::optional<int> stream_index) {
+  AVStream* scanned_stream =
+      format_context_->streams[resolve_stream_index(stream_index)];
+
   std::vector<ScannedPacket> packets;
-  if (stream_->nb_frames > 0) {
-    packets.reserve(static_cast<size_t>(stream_->nb_frames));
+  if (scanned_stream->nb_frames > 0) {
+    packets.reserve(static_cast<size_t>(scanned_stream->nb_frames));
   }
 
-  seek(0);
+  seek(0, scanned_stream->index);
 
   while (true) {
     ReferenceAVPacket packet(auto_packet_);
     int status =
-        read_next_packet(format_context_.get(), active_stream_index_, packet);
+        read_next_packet(format_context_.get(), scanned_stream->index, packet);
     if (status == AVERROR_EOF) {
       break;
     }
@@ -224,14 +297,14 @@ FrameIndex Demuxer::scan() {
         return a.pts < b.pts;
       });
 
-  seek(0);
+  seek(0, scanned_stream->index);
 
   auto num_frames = static_cast<int64_t>(packets.size());
   FrameIndex index{
       torch::stable::empty({num_frames}, kStableInt64),
       torch::stable::empty({num_frames}, kStableInt64),
       torch::stable::empty({num_frames}, kStableBool),
-      stream_->time_base};
+      scanned_stream->time_base};
 
   auto pts = mutable_accessor<int64_t, 1>(index.pts);
   auto duration = mutable_accessor<int64_t, 1>(index.duration);
@@ -246,11 +319,16 @@ FrameIndex Demuxer::scan() {
 }
 
 UniqueAVPacket Demuxer::next_packet() {
+  STD_TORCH_CHECK(
+      !active_stream_indices_.empty(),
+      "This demuxer isn't following any stream yet.");
+  has_demuxed_ = true;
+
   // TODO_API_BREAKDOWN CC P2: Not a fan of the ReferenceAVPacket / AutoAVPacket
   // / UniqueAVPacket dance here. Can we simplify?
   ReferenceAVPacket packet(auto_packet_);
   int status =
-      read_next_packet(format_context_.get(), active_stream_index_, packet);
+      read_next_packet(format_context_.get(), active_stream_indices_, packet);
   if (status == AVERROR_EOF) {
     return UniqueAVPacket{};
   }

--- a/src/torchcodec/_core/Demuxer.h
+++ b/src/torchcodec/_core/Demuxer.h
@@ -26,14 +26,20 @@ int read_next_packet(
     int active_stream_index,
     ReferenceAVPacket& packet);
 
+// Same, for a demuxer following more than one stream: the packet comes from
+// whichever of `active_stream_indices` has the next one.
+int read_next_packet(
+    AVFormatContext* format_context,
+    const std::vector<int>& active_stream_indices,
+    ReferenceAVPacket& packet);
+
 std::string get_seek_error_message(
     const AVFormatContext* format_context,
     int64_t desired_pts,
     int status);
 
-// The frames of the active stream, in presentation order: three parallel
-// tensors of length N, plus the time base `pts` and `duration` are expressed
-// in.
+// The frames of one stream, in presentation order: three parallel tensors of
+// length N, plus the time base `pts` and `duration` are expressed in.
 struct FrameIndex {
   torch::stable::Tensor pts; // int64 [N]
   torch::stable::Tensor duration; // int64 [N]
@@ -41,42 +47,43 @@ struct FrameIndex {
   AVRational time_base;
 };
 
-// Demux building block: owns an AVFormatContext, selects one stream of the
-// requested media type, and yields its (compressed) packets. Does no decoding.
-// Not thread-safe.
+// Demux building block: owns an AVFormatContext, follows one or more of its
+// streams, and yields their (compressed) packets. Does no decoding. Not
+// thread-safe.
 class FORCE_PUBLIC_VISIBILITY Demuxer {
  public:
-  explicit Demuxer(
-      const std::string& file_path,
-      std::optional<int> stream_index = std::nullopt,
-      AVMediaType media_type = AVMEDIA_TYPE_VIDEO);
+  // Both constructors open the container and probe it, without following any
+  // stream: add_stream() must be called before anything can be demuxed.
+  explicit Demuxer(const std::string& file_path);
 
-  explicit Demuxer(
-      std::unique_ptr<AVIOContextHolder> avio_context_holder,
-      std::optional<int> stream_index = std::nullopt,
-      AVMediaType media_type = AVMEDIA_TYPE_VIDEO);
+  explicit Demuxer(std::unique_ptr<AVIOContextHolder> avio_context_holder);
 
-  // Returns the next packet for the active stream as a freshly-allocated
-  // packet, or a null packet at end of stream.
+  // Starts following the stream at `stream_index`, or the best stream of
+  // `media_type` when it is left unspecified, and returns its index (which is
+  // absolute across all media types).
+  int add_stream(std::optional<int> stream_index, AVMediaType media_type);
+
+  // Returns the next packet of whichever followed stream has one, as a
+  // freshly-allocated packet, or a null packet at end of stream. Which stream
+  // it belongs to is on the packet itself, as `stream_index`.
   UniqueAVPacket next_packet();
 
-  void seek(double seconds);
+  // Moves the *container*: every followed stream jumps, so every decoder fed by
+  // this demuxer must be reset. The target is resolved against `stream_index`,
+  // or against get_reference_stream() when it is left unspecified.
+  void seek(double seconds, std::optional<int> stream_index = std::nullopt);
 
-  // Demuxes the entire stream, without decoding, and returns one entry per
-  // frame sorted by pts. Leaves the demuxer back at the start of the stream,
+  // Demuxes one stream entirely, without decoding, and returns one entry per
+  // frame sorted by pts. Leaves the demuxer back at the start of the container,
   // and keeps no state of its own.
-  FrameIndex scan();
+  FrameIndex scan(std::optional<int> stream_index = std::nullopt);
 
-  AVStream* active_stream() const {
-    return stream_;
-  }
+  // The index passed in, validated, or the only followed stream when it is left
+  // unspecified.
+  int resolve_stream_index(std::optional<int> stream_index) const;
 
-  int active_stream_index() const {
-    return active_stream_index_;
-  }
-
-  AVMediaType media_type() const {
-    return media_type_;
+  const std::vector<int>& active_stream_indices() const {
+    return active_stream_indices_;
   }
 
   const UniqueDecodingAVFormatContext& format_context() const {
@@ -84,16 +91,24 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   }
 
  private:
-  void validate_requested_stream(int stream_index);
-  void select_stream(std::optional<int> stream_index);
+  void find_stream_info();
+  void validate_requested_stream(int stream_index, AVMediaType media_type);
+  // The stream a seek is resolved against when the caller doesn't name one:
+  // simply the first one that was added. A seek is resolved in a single
+  // stream's time base and lands on that stream's keyframes, so which one it is
+  // does matter - but picking by media type would make the default depend on
+  // what the container happens to hold, where first-added is the caller's own
+  // ordering. Pass a stream to seek() to override it.
+  AVStream* get_reference_stream() const;
 
   // Declared before format_context_ so that it outlives it: the format context
   // reads through the AVIOContext this holds.
   std::unique_ptr<AVIOContextHolder> avio_context_holder_;
   UniqueDecodingAVFormatContext format_context_;
-  int active_stream_index_ = -1;
-  AVStream* stream_ = nullptr;
-  AVMediaType media_type_ = AVMEDIA_TYPE_VIDEO;
+  // In the order they were added. A handful of entries at most, so this is
+  // scanned linearly.
+  std::vector<int> active_stream_indices_;
+  bool has_demuxed_ = false;
   AutoAVPacket auto_packet_;
 };
 

--- a/src/torchcodec/_core/PacketDecoder.cpp
+++ b/src/torchcodec/_core/PacketDecoder.cpp
@@ -59,9 +59,13 @@ const AVCodec* find_decoder(
 
 PacketDecoder::PacketDecoder(
     const Demuxer& demuxer,
+    std::optional<int> stream_index,
     const StableDevice& device,
-    std::optional<int> ffmpeg_thread_count)
-    : media_type_(demuxer.media_type()) {
+    std::optional<int> ffmpeg_thread_count) {
+  AVStream* stream = demuxer.format_context()
+                         ->streams[demuxer.resolve_stream_index(stream_index)];
+  media_type_ = stream->codecpar->codec_type;
+
   bool is_audio = media_type_ == AVMEDIA_TYPE_AUDIO;
   STD_TORCH_CHECK(
       !is_audio || device.type() == kStableCPU,
@@ -72,7 +76,6 @@ PacketDecoder::PacketDecoder(
       device_interface_ != nullptr,
       "Failed to create device interface. This should never happen, please report.");
 
-  AVStream* stream = demuxer.active_stream();
   time_base_ = stream->time_base;
 
   is_mpeg_ps_ =

--- a/src/torchcodec/_core/PacketDecoder.h
+++ b/src/torchcodec/_core/PacketDecoder.h
@@ -31,11 +31,12 @@ SharedAVCodecContext create_and_open_codec_context(
 
 // Decode building block: turns compressed packets into decoded frames - (YUV)
 // pictures for a video stream, samples in the codec's own format for an audio
-// one. Configured from a Demuxer's active stream; stateful. Not thread-safe.
+// one. Configured from one of a Demuxer's streams; stateful. Not thread-safe.
 class FORCE_PUBLIC_VISIBILITY PacketDecoder {
  public:
   explicit PacketDecoder(
       const Demuxer& demuxer,
+      std::optional<int> stream_index = std::nullopt,
       const StableDevice& device = StableDevice(kStableCPU),
       std::optional<int> ffmpeg_thread_count = std::nullopt);
 

--- a/src/torchcodec/_core/_decoder_utils.py
+++ b/src/torchcodec/_core/_decoder_utils.py
@@ -76,26 +76,27 @@ def create_decoder(
 def create_demuxer(
     *,
     source: str | Path | io.RawIOBase | io.BufferedReader | bytes | Tensor,
-    stream_index: int | None = None,
-    media_type: str = "video",
 ) -> Tensor:
+    """Open a container and probe its header. No stream is followed yet, and no
+    packet is read: call ``_blocks_demuxer_add_stream`` for each stream to
+    follow, before demuxing anything."""
     load_core_libraries()
     if isinstance(source, str):
-        return _blocks_create_demuxer_from_file(source, stream_index, media_type)
+        return _blocks_create_demuxer_from_file(source)
     elif isinstance(source, Path):
-        return _blocks_create_demuxer_from_file(str(source), stream_index, media_type)
+        return _blocks_create_demuxer_from_file(str(source))
     elif isinstance(source, bytes):
-        return _blocks_create_demuxer_from_bytes(source, stream_index, media_type)
+        return _blocks_create_demuxer_from_bytes(source)
     elif isinstance(source, Tensor):
-        return _blocks_create_demuxer_from_tensor(source, stream_index, media_type)
+        return _blocks_create_demuxer_from_tensor(source)
     elif isinstance(source, (io.RawIOBase, io.BufferedReader)):
-        return _blocks_create_demuxer_from_file_like(source, stream_index, media_type)
+        return _blocks_create_demuxer_from_file_like(source)
     elif isinstance(source, io.TextIOBase):
         raise TypeError(
             "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
         )
     elif hasattr(source, "read") and hasattr(source, "seek"):
-        return _blocks_create_demuxer_from_file_like(source, stream_index, media_type)
+        return _blocks_create_demuxer_from_file_like(source)
 
     raise TypeError(
         f"Unknown source type: {type(source)}. "

--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -33,6 +33,7 @@ FFMPEG_OP_NAMES = frozenset(
         "_blocks_create_demuxer_from_tensor",
         "_blocks_create_demuxer_from_bytes",
         "_blocks_create_demuxer_from_file_like",
+        "_blocks_demuxer_add_stream",
         "_blocks_demuxer_next_packet",
         "_blocks_demuxer_seek",
         "_blocks_demuxer_scan",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -101,6 +101,7 @@ _blocks_create_demuxer_from_tensor = (
 _blocks_create_demuxer_from_file_like_context = (
     torch.ops.torchcodec_ns._blocks_create_demuxer_from_file_like.default
 )
+_blocks_demuxer_add_stream = torch.ops.torchcodec_ns._blocks_demuxer_add_stream.default
 _blocks_demuxer_next_packet = (
     torch.ops.torchcodec_ns._blocks_demuxer_next_packet.default
 )
@@ -224,28 +225,18 @@ def create_from_file_like(
     )
 
 
-def _blocks_create_demuxer_from_bytes(
-    video_bytes: bytes,
-    stream_index: int | None = None,
-    media_type: str = "video",
-) -> torch.Tensor:
-    return _blocks_create_demuxer_from_tensor(
-        _bytes_to_tensor(video_bytes), stream_index, media_type
-    )
+def _blocks_create_demuxer_from_bytes(video_bytes: bytes) -> torch.Tensor:
+    return _blocks_create_demuxer_from_tensor(_bytes_to_tensor(video_bytes))
 
 
 def _blocks_create_demuxer_from_file_like(
     file_like: io.RawIOBase | io.BufferedReader,
-    stream_index: int | None = None,
-    media_type: str = "video",
 ) -> torch.Tensor:
     assert _pybind_ops is not None
     return _blocks_create_demuxer_from_file_like_context(
         _pybind_ops.create_file_like_context(
             file_like, False  # False means not for writing
         ),
-        stream_index,
-        media_type,
     )
 
 

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -74,18 +74,20 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
       "get_frames_by_pts_in_range_audio(Tensor(a!) decoder, *, float start_seconds, float? stop_seconds) -> (Tensor, Tensor)");
   m.def(
       "get_frames_by_pts(Tensor(a!) decoder, *, Tensor timestamps) -> (Tensor, Tensor, Tensor)");
+  m.def("_blocks_create_demuxer_from_file(str filename) -> Tensor");
+  m.def("_blocks_create_demuxer_from_tensor(Tensor video_tensor) -> Tensor");
   m.def(
-      "_blocks_create_demuxer_from_file(str filename, int? stream_index=None, str media_type=\"video\") -> Tensor");
+      "_blocks_create_demuxer_from_file_like(int file_like_context) -> Tensor");
   m.def(
-      "_blocks_create_demuxer_from_tensor(Tensor video_tensor, int? stream_index=None, str media_type=\"video\") -> Tensor");
+      "_blocks_demuxer_add_stream(Tensor(a!) demuxer, int? stream_index=None, str media_type=\"video\") -> int");
   m.def(
-      "_blocks_create_demuxer_from_file_like(int file_like_context, int? stream_index=None, str media_type=\"video\") -> Tensor");
-  m.def("_blocks_demuxer_next_packet(Tensor(a!) demuxer) -> (Tensor, bool)");
-  m.def("_blocks_demuxer_seek(Tensor(a!) demuxer, float seconds) -> ()");
+      "_blocks_demuxer_next_packet(Tensor(a!) demuxer) -> (Tensor, bool, int)");
   m.def(
-      "_blocks_demuxer_scan(Tensor(a!) demuxer) -> (Tensor, Tensor, Tensor, int, int)");
+      "_blocks_demuxer_seek(Tensor(a!) demuxer, float seconds, int? stream_index=None) -> ()");
   m.def(
-      "_blocks_create_packet_decoder(Tensor demuxer, *, int? num_threads=None, str device=\"cpu\") -> Tensor");
+      "_blocks_demuxer_scan(Tensor(a!) demuxer, int? stream_index=None) -> (Tensor, Tensor, Tensor, int, int)");
+  m.def(
+      "_blocks_create_packet_decoder(Tensor demuxer, *, int? stream_index=None, int? num_threads=None, str device=\"cpu\") -> Tensor");
   m.def(
       "_blocks_packet_decoder_send_packet(Tensor(a!) decoder, Tensor packet) -> int");
   m.def("_blocks_packet_decoder_send_eof(Tensor(a!) decoder) -> int");
@@ -830,19 +832,13 @@ AVMediaType parse_media_type(const std::string& media_type) {
   return AVMEDIA_TYPE_AUDIO;
 }
 
-torch::stable::Tensor _blocks_create_demuxer_from_file(
-    std::string filename,
-    std::optional<int64_t> stream_index,
-    std::string media_type) {
-  auto demuxer = std::make_unique<Demuxer>(
-      filename, to_optional_int(stream_index), parse_media_type(media_type));
+torch::stable::Tensor _blocks_create_demuxer_from_file(std::string filename) {
+  auto demuxer = std::make_unique<Demuxer>(filename);
   return wrap_pointer_to_tensor<Demuxer>(std::move(demuxer));
 }
 
 torch::stable::Tensor _blocks_create_demuxer_from_tensor(
-    const torch::stable::Tensor& video_tensor,
-    std::optional<int64_t> stream_index,
-    std::string media_type) {
+    const torch::stable::Tensor& video_tensor) {
   STD_TORCH_CHECK(
       video_tensor.is_contiguous(), "video_tensor must be contiguous");
   STD_TORCH_CHECK(
@@ -851,17 +847,12 @@ torch::stable::Tensor _blocks_create_demuxer_from_tensor(
 
   auto avio_context_holder = std::make_unique<AVIOContextHolder>(
       std::make_unique<TensorReadIO>(video_tensor), /*is_for_writing=*/false);
-  auto demuxer = std::make_unique<Demuxer>(
-      std::move(avio_context_holder),
-      to_optional_int(stream_index),
-      parse_media_type(media_type));
+  auto demuxer = std::make_unique<Demuxer>(std::move(avio_context_holder));
   return wrap_pointer_to_tensor<Demuxer>(std::move(demuxer));
 }
 
 torch::stable::Tensor _blocks_create_demuxer_from_file_like(
-    int64_t file_like_context,
-    std::optional<int64_t> stream_index,
-    std::string media_type) {
+    int64_t file_like_context) {
   auto file_like_context_ptr =
       reinterpret_cast<IOInterface*>(file_like_context);
   STD_TORCH_CHECK(
@@ -871,28 +862,40 @@ torch::stable::Tensor _blocks_create_demuxer_from_file_like(
   auto avio_context_holder = std::make_unique<AVIOContextHolder>(
       std::unique_ptr<IOInterface>(file_like_context_ptr),
       /*is_for_writing=*/false);
-  auto demuxer = std::make_unique<Demuxer>(
-      std::move(avio_context_holder),
-      to_optional_int(stream_index),
-      parse_media_type(media_type));
+  auto demuxer = std::make_unique<Demuxer>(std::move(avio_context_holder));
   return wrap_pointer_to_tensor<Demuxer>(std::move(demuxer));
 }
 
-// (packet_handle, is_eof). On EOF the packet_handle is a dummy tensor that must
-// not be used. Native bool avoids per-frame .item() overhead in Python.
-using OpsPacketOutput = std::tuple<torch::stable::Tensor, bool>;
+int64_t _blocks_demuxer_add_stream(
+    torch::stable::Tensor& demuxer,
+    std::optional<int64_t> stream_index,
+    std::string media_type) {
+  return unwrap_tensor_to_pointer<Demuxer>(demuxer)->add_stream(
+      to_optional_int(stream_index), parse_media_type(media_type));
+}
+
+// (packet_handle, is_eof, stream_index). On EOF the packet_handle is a dummy
+// tensor that must not be used and stream_index is -1. Native bool avoids
+// per-frame .item() overhead in Python.
+using OpsPacketOutput = std::tuple<torch::stable::Tensor, bool, int64_t>;
 
 OpsPacketOutput _blocks_demuxer_next_packet(torch::stable::Tensor& demuxer) {
   Demuxer* demuxer_ptr = unwrap_tensor_to_pointer<Demuxer>(demuxer);
   UniqueAVPacket packet = demuxer_ptr->next_packet();
   if (packet == nullptr) {
-    return std::make_tuple(torch::stable::full({1}, 0, kStableInt64), true);
+    return std::make_tuple(torch::stable::full({1}, 0, kStableInt64), true, -1);
   }
-  return std::make_tuple(wrap_pointer_to_tensor(std::move(packet)), false);
+  int64_t stream_index = packet->stream_index;
+  return std::make_tuple(
+      wrap_pointer_to_tensor(std::move(packet)), false, stream_index);
 }
 
-void _blocks_demuxer_seek(torch::stable::Tensor& demuxer, double seconds) {
-  unwrap_tensor_to_pointer<Demuxer>(demuxer)->seek(seconds);
+void _blocks_demuxer_seek(
+    torch::stable::Tensor& demuxer,
+    double seconds,
+    std::optional<int64_t> stream_index) {
+  unwrap_tensor_to_pointer<Demuxer>(demuxer)->seek(
+      seconds, to_optional_int(stream_index));
 }
 
 // (pts, duration, is_key_frame, time_base_num, time_base_den). pts and duration
@@ -904,8 +907,11 @@ using OpsScanOutput = std::tuple<
     int64_t,
     int64_t>;
 
-OpsScanOutput _blocks_demuxer_scan(torch::stable::Tensor& demuxer) {
-  FrameIndex index = unwrap_tensor_to_pointer<Demuxer>(demuxer)->scan();
+OpsScanOutput _blocks_demuxer_scan(
+    torch::stable::Tensor& demuxer,
+    std::optional<int64_t> stream_index) {
+  FrameIndex index = unwrap_tensor_to_pointer<Demuxer>(demuxer)->scan(
+      to_optional_int(stream_index));
   return std::make_tuple(
       index.pts,
       index.duration,
@@ -916,6 +922,7 @@ OpsScanOutput _blocks_demuxer_scan(torch::stable::Tensor& demuxer) {
 
 torch::stable::Tensor _blocks_create_packet_decoder(
     torch::stable::Tensor& demuxer,
+    std::optional<int64_t> stream_index,
     std::optional<int64_t> num_threads,
     std::string device) {
   Demuxer* demuxer_ptr = unwrap_tensor_to_pointer<Demuxer>(demuxer);
@@ -925,7 +932,10 @@ torch::stable::Tensor _blocks_create_packet_decoder(
     thread_count = static_cast<int>(num_threads.value());
   }
   auto decoder = std::make_unique<PacketDecoder>(
-      *demuxer_ptr, StableDevice(device), thread_count);
+      *demuxer_ptr,
+      to_optional_int(stream_index),
+      StableDevice(device),
+      thread_count);
   return wrap_pointer_to_tensor<PacketDecoder>(std::move(decoder));
 }
 
@@ -1672,6 +1682,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
       "get_frames_by_pts_in_range_audio",
       TORCH_BOX(&get_frames_by_pts_in_range_audio));
   m.impl("get_frames_by_pts", TORCH_BOX(&get_frames_by_pts));
+  m.impl("_blocks_demuxer_add_stream", TORCH_BOX(&_blocks_demuxer_add_stream));
   m.impl(
       "_blocks_demuxer_next_packet", TORCH_BOX(&_blocks_demuxer_next_packet));
   m.impl("_blocks_demuxer_seek", TORCH_BOX(&_blocks_demuxer_seek));

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -16,6 +16,7 @@ from torch import Tensor
 
 from torchcodec._core._decoder_utils import create_demuxer
 from torchcodec._core.ops import (
+    _blocks_demuxer_add_stream,
     _blocks_demuxer_next_packet,
     _blocks_demuxer_scan,
     _blocks_demuxer_seek,
@@ -180,13 +181,14 @@ class _BaseDemuxer:
         *,
         stream_index: int | None = None,
     ):
-        self._handle = create_demuxer(
-            source=source, stream_index=stream_index, media_type=self._media_type
+        self._handle = create_demuxer(source=source)
+        self._stream_index = _blocks_demuxer_add_stream(
+            self._handle, stream_index, self._media_type
         )
 
     def next_packet(self) -> Packet | None:
         """Return the next :class:`Packet`, or ``None`` at end of stream."""
-        handle, is_eof = _blocks_demuxer_next_packet(self._handle)
+        handle, is_eof, _ = _blocks_demuxer_next_packet(self._handle)
         return None if is_eof else Packet(handle)
 
     def seek(self, seconds: float) -> None:
@@ -204,7 +206,7 @@ class _BaseDemuxer:
         decoding would give - until it re-primes. Decoding a margin before the
         target and discarding it is the caller's responsibility.
         """
-        _blocks_demuxer_seek(self._handle, float(seconds))
+        _blocks_demuxer_seek(self._handle, float(seconds), self._stream_index)
 
     def __iter__(self):
         while True:
@@ -261,7 +263,7 @@ class VideoDemuxer(_BaseDemuxer):
         ``seek()``. Nothing is cached: calling this twice scans twice.
         """
         pts, duration, is_key_frame, time_base_num, time_base_den = (
-            _blocks_demuxer_scan(self._handle)
+            _blocks_demuxer_scan(self._handle, self._stream_index)
         )
         return FrameIndex(
             is_key_frame=is_key_frame,

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -40,7 +40,10 @@ class _BasePacketDecoder(Generic[_Decoded]):
 
     def __init__(self, demuxer, device_str: str):
         self._handle = _blocks_create_packet_decoder(
-            demuxer._handle, num_threads=1, device=device_str
+            demuxer._handle,
+            stream_index=demuxer._stream_index,
+            num_threads=1,
+            device=device_str,
         )
         self._drained = False
 

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -22,6 +22,8 @@ import pytest
 import torch
 from PIL import Image, ImageOps
 from torchcodec import _core, ffmpeg_major_version, FrameBatch
+from torchcodec._core._decoder_utils import create_demuxer
+from torchcodec._core.ops import _blocks_demuxer_add_stream, _blocks_demuxer_next_packet
 from torchcodec._frame import Frame
 from torchcodec.decoders import (
     AudioDecoder,
@@ -3657,6 +3659,47 @@ class TestBlocks:
                 assert frame.duration_seconds >= 0
 
         assert num_packets > 0
+
+    def test_ops_follow_several_streams(self):
+        # The Python API for this comes later. At the op level a demuxer can
+        # already follow several streams at once, and it tags every packet with
+        # the stream it came from - which is what routes it to its decoder.
+        handle = create_demuxer(source=NASA_VIDEO.path)
+        video_index = _blocks_demuxer_add_stream(handle, None, "video")
+        audio_index = _blocks_demuxer_add_stream(handle, None, "audio")
+        assert video_index != audio_index
+
+        counts = {video_index: 0, audio_index: 0}
+        while True:
+            _, is_eof, stream_index = _blocks_demuxer_next_packet(handle)
+            if is_eof:
+                break
+            counts[stream_index] += 1
+
+        assert counts[video_index] > 0
+        assert counts[audio_index] > 0
+        # And a single pass really did produce both, rather than one after the
+        # other: the same file demuxed alone gives the same counts.
+        assert counts[video_index] == len(list(VideoDemuxer(NASA_VIDEO.path)))
+        assert counts[audio_index] == len(list(AudioDemuxer(NASA_VIDEO.path)))
+
+    def test_ops_add_stream_errors(self):
+        handle = create_demuxer(source=NASA_VIDEO.path)
+
+        # nasa_13013.mp4 carries subtitle streams, which we can demux packets
+        # for but have no decoder for.
+        with pytest.raises(RuntimeError, match="is not a video stream"):
+            _blocks_demuxer_add_stream(handle, 2, "video")
+        with pytest.raises(RuntimeError, match="not a valid stream"):
+            _blocks_demuxer_add_stream(handle, 99, "video")
+
+        _blocks_demuxer_add_stream(handle, 3, "video")
+        with pytest.raises(RuntimeError, match="already being demuxed"):
+            _blocks_demuxer_add_stream(handle, 3, "video")
+
+        _blocks_demuxer_next_packet(handle)
+        with pytest.raises(RuntimeError, match="before the first packet"):
+            _blocks_demuxer_add_stream(handle, 4, "audio")
 
     # The three decode stages, each expressed as a generator that transforms an
     # iterator of inputs into an iterator of outputs. They compose directly (the


### PR DESCRIPTION
The demuxer selected exactly one stream at construction. It now opens and probes in the constructor, and follows streams through `add_stream()`, which can be called more than once; `av_read_frame`'s output is filtered against the set, and each packet is handed back with the stream index it came from.

`seek()` takes the stream to resolve against, since FFmpeg resolves a seek in one stream's time base and lands on that stream's keyframes: it's stream-dependent. By default, it picks the first followed stream as passed by the `streams=` parameter at Demuxer creation.

No Python API changes.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>