### PR TITLE
Scan every followed video stream in one pass, and only before demuxing

### DIFF
--- a/src/torchcodec/_core/Demuxer.cpp
+++ b/src/torchcodec/_core/Demuxer.cpp
@@ -249,29 +249,37 @@ void Demuxer::seek(double seconds, std::optional<int> stream_index) {
       get_seek_error_message(format_context_.get(), desired_pts, status));
 }
 
-namespace {
-struct ScannedPacket {
-  int64_t pts;
-  int64_t duration;
-  bool is_key_frame;
-};
-} // namespace
+void Demuxer::scan_all_video_streams() {
+  if (has_scanned_) {
+    return;
+  }
+  STD_TORCH_CHECK(
+      !has_demuxed_,
+      "A scan reads the container from end to end and rewinds it, so it has to "
+      "happen before any packet is demuxed. Scan up front, or build a second "
+      "demuxer for it.");
 
-FrameIndex Demuxer::scan(std::optional<int> stream_index) {
-  AVStream* scanned_stream =
-      format_context_->streams[resolve_stream_index(stream_index)];
-
-  std::vector<ScannedPacket> packets;
-  if (scanned_stream->nb_frames > 0) {
-    packets.reserve(static_cast<size_t>(scanned_stream->nb_frames));
+  std::vector<int> video_stream_indices;
+  for (int index : active_stream_indices_) {
+    AVStream* candidate = format_context_->streams[index];
+    if (candidate->codecpar->codec_type != AVMEDIA_TYPE_VIDEO) {
+      continue;
+    }
+    video_stream_indices.push_back(index);
+    auto& packets = scanned_packets_[index];
+    if (candidate->nb_frames > 0) {
+      packets.reserve(static_cast<size_t>(candidate->nb_frames));
+    }
   }
 
-  seek(0, scanned_stream->index);
+  seek(0);
 
+  // One pass, however many video streams are being followed: the I/O is what a
+  // scan costs, and it is the same read for all of them.
   while (true) {
     ReferenceAVPacket packet(auto_packet_);
     int status =
-        read_next_packet(format_context_.get(), scanned_stream->index, packet);
+        read_next_packet(format_context_.get(), video_stream_indices, packet);
     if (status == AVERROR_EOF) {
       break;
     }
@@ -284,20 +292,40 @@ FrameIndex Demuxer::scan(std::optional<int> stream_index) {
       continue;
     }
 
-    packets.push_back(
+    scanned_packets_[packet->stream_index].push_back(
         {get_pts_or_dts(packet),
          packet->duration,
          (packet->flags & AV_PKT_FLAG_KEY) != 0});
   }
 
+  seek(0);
+  has_scanned_ = true;
+}
+
+// TODO_API_BREAKDOWN DESIGN P1 I'm starting to wonder if this should be named
+// 'scan()' in the python API. We only really scan once, but this is a
+// per-stream call. demuxer.scan(0) pays for the scan and demuxer.scan(1)
+// doesn't, but the 'scan()' name suggests that it does. Maybe this should be
+// .get_frame_index() (but 'index' is still overloaded). Ah.
+FrameIndex Demuxer::scan(std::optional<int> stream_index) {
+  AVStream* scanned_stream =
+      format_context_->streams[resolve_stream_index(stream_index)];
+  STD_TORCH_CHECK(
+      scanned_stream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO,
+      "Only a video stream can be scanned: a frame index describes keyframes "
+      "and frame positions, and the stream at index ",
+      scanned_stream->index,
+      " has neither.");
+
+  scan_all_video_streams();
+
+  // Sorting and building the tensors is per-stream work, so it is only done for
+  // the streams whose index is actually asked for.
+  std::vector<FrameInfo>& packets = scanned_packets_.at(scanned_stream->index);
   std::stable_sort(
       packets.begin(),
       packets.end(),
-      [](const ScannedPacket& a, const ScannedPacket& b) {
-        return a.pts < b.pts;
-      });
-
-  seek(0, scanned_stream->index);
+      [](const FrameInfo& a, const FrameInfo& b) { return a.pts < b.pts; });
 
   auto num_frames = static_cast<int64_t>(packets.size());
   FrameIndex index{

--- a/src/torchcodec/_core/Demuxer.h
+++ b/src/torchcodec/_core/Demuxer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -37,6 +38,20 @@ std::string get_seek_error_message(
     const AVFormatContext* format_context,
     int64_t desired_pts,
     int status);
+
+// One demuxed packet, as a scan records it before sorting.
+//
+// Deliberately the same name as SingleStreamDecoder::FrameInfo, which its own
+// scan produces: these describe the same thing, one entry per frame of a
+// stream, and differ only in how they say it - `duration` here against
+// `next_pts` there, and the frame's index implicit in the vector position
+// rather than stored. The two scans should probably be unified eventually;
+// until then the shared name is the reminder.
+struct FrameInfo {
+  int64_t pts;
+  int64_t duration;
+  bool is_key_frame;
+};
 
 // The frames of one stream, in presentation order: three parallel tensors of
 // length N, plus the time base `pts` and `duration` are expressed in.
@@ -74,8 +89,12 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   void seek(double seconds, std::optional<int> stream_index = std::nullopt);
 
   // Demuxes one stream entirely, without decoding, and returns one entry per
-  // frame sorted by pts. Leaves the demuxer back at the start of the container,
-  // and keeps no state of its own.
+  // frame sorted by pts. Leaves the demuxer back at the start of the container.
+  //
+  // The demux pass this needs covers every followed video stream at once and
+  // happens only once per demuxer, so indexing a second stream costs no I/O.
+  // Only legal before the first packet is demuxed, which is what makes the
+  // rewind harmless: nothing has been fed to a decoder yet.
   FrameIndex scan(std::optional<int> stream_index = std::nullopt);
 
   // The index passed in, validated, or the only followed stream when it is left
@@ -100,6 +119,9 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   // what the container happens to hold, where first-added is the caller's own
   // ordering. Pass a stream to seek() to override it.
   AVStream* get_reference_stream() const;
+  // Phase one of a scan: read the container once, bucketing the packets of
+  // every followed video stream. Idempotent.
+  void scan_all_video_streams();
 
   // Declared before format_context_ so that it outlives it: the format context
   // reads through the AVIOContext this holds.
@@ -109,6 +131,10 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   // scanned linearly.
   std::vector<int> active_stream_indices_;
   bool has_demuxed_ = false;
+  // Filled by scan_all_video_streams(), keyed by stream index. Sorted lazily,
+  // per stream, by scan().
+  std::map<int, std::vector<FrameInfo>> scanned_packets_;
+  bool has_scanned_ = false;
   AutoAVPacket auto_packet_;
 };
 

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -185,6 +185,7 @@ class _BaseDemuxer:
         self._stream_index = _blocks_demuxer_add_stream(
             self._handle, stream_index, self._media_type
         )
+        self._frame_index: FrameIndex | None = None
 
     def next_packet(self) -> Packet | None:
         """Return the next :class:`Packet`, or ``None`` at end of stream."""
@@ -255,23 +256,27 @@ class VideoDemuxer(_BaseDemuxer):
 
         This reads the whole file, and it is the only way to know the stream's
         exact frame count, timestamps and :term:`keyframe` positions: the
-        container header can be wrong about all of them.
+        container header can be wrong about all of them. The result is cached:
+        calling this twice scans once.
 
-        The index always covers the entire stream, wherever the demuxer
-        currently is, and the demuxer is left back at the start - so a
-        :class:`VideoPacketDecoder` built from it must be ``reset()``, as after a
-        ``seek()``. Nothing is cached: calling this twice scans twice.
+        **A scan has to happen before any packet is demuxed**, and calling it
+        later raises. That restriction is what keeps it cheap to use: the scan
+        rewinds the demuxer, and since nothing has been fed to a decoder yet,
+        there is nothing to ``reset()`` afterwards.
         """
+        if self._frame_index is not None:
+            return self._frame_index
         pts, duration, is_key_frame, time_base_num, time_base_den = (
             _blocks_demuxer_scan(self._handle, self._stream_index)
         )
-        return FrameIndex(
+        self._frame_index = FrameIndex(
             is_key_frame=is_key_frame,
             _pts=pts,
             _duration=duration,
             _time_base_num=time_base_num,
             _time_base_den=time_base_den,
         )
+        return self._frame_index
 
 
 class AudioDemuxer(_BaseDemuxer):

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -23,7 +23,11 @@ import torch
 from PIL import Image, ImageOps
 from torchcodec import _core, ffmpeg_major_version, FrameBatch
 from torchcodec._core._decoder_utils import create_demuxer
-from torchcodec._core.ops import _blocks_demuxer_add_stream, _blocks_demuxer_next_packet
+from torchcodec._core.ops import (
+    _blocks_demuxer_add_stream,
+    _blocks_demuxer_next_packet,
+    _blocks_demuxer_scan,
+)
 from torchcodec._frame import Frame
 from torchcodec.decoders import (
     AudioDecoder,
@@ -4985,8 +4989,9 @@ class TestBlocks:
     @pytest.mark.parametrize("device", _block_devices())
     def test_scan_leaves_demuxer_at_the_start(self, video, device):
         # A scan reads the file all the way to the end and then rewinds, so a
-        # pipeline built on that same demuxer still decodes the whole stream -
-        # and a scan started from somewhere else gives the very same index.
+        # pipeline built on that same demuxer still decodes the whole stream.
+        # The decoder needs no reset(): the scan happened before it was fed
+        # anything.
         demuxer = VideoDemuxer(video.path)
         index = demuxer.scan()
 
@@ -5000,10 +5005,81 @@ class TestBlocks:
         for frame, expected_pts in zip(frames, index.pts_seconds):
             assert frame.pts_seconds == expected_pts
 
-        demuxer.seek(index.end_stream_seconds_from_content / 2)
-        torch.testing.assert_close(
-            demuxer.scan().pts_seconds, index.pts_seconds, atol=0, rtol=0
-        )
+    def test_scan_after_demuxing_raises(self):
+        # The scan rewinds the container, which would silently desynchronise
+        # every decoder already being fed from it.
+        demuxer = VideoDemuxer(NASA_VIDEO.path)
+        demuxer.next_packet()
+
+        with pytest.raises(RuntimeError, match="before any packet is demuxed"):
+            demuxer.scan()
+
+    def test_scan_is_cached(self):
+        demuxer = VideoDemuxer(NASA_VIDEO.path)
+        assert demuxer.scan() is demuxer.scan()
+
+    def test_scan_rewind_matches_a_fresh_demuxer(self):
+        # scan() rewinds with a seek to 0 rather than reopening the container,
+        # and on a file whose edit list discards the first packets those are not
+        # obviously the same thing. What comes out after a scan has to be
+        # exactly what a demuxer that never scanned gives.
+        video = DISCARD_FIRST_KEYFRAME_VIDEO
+
+        scanned = VideoDemuxer(video.path)
+        scanned.scan()
+        after_scan = [
+            frame.pts_seconds
+            for frame in self._decode(VideoPacketDecoder(scanned), scanned)
+        ]
+
+        fresh = VideoDemuxer(video.path)
+        never_scanned = [
+            frame.pts_seconds
+            for frame in self._decode(VideoPacketDecoder(fresh), fresh)
+        ]
+
+        assert after_scan == never_scanned
+        assert len(after_scan) == 25
+
+    def test_scanning_several_video_streams_reads_the_file_once(self):
+        # Sorting and building tensors is per-stream, but the I/O - which is
+        # what a scan actually costs - is shared.
+        class CountingFileLike:
+            def __init__(self, path):
+                self._file = open(path, "rb")
+                self.bytes_read = 0
+
+            def read(self, size):
+                data = self._file.read(size)
+                self.bytes_read += len(data)
+                return data
+
+            def seek(self, offset, whence):
+                return self._file.seek(offset, whence)
+
+        one_stream = CountingFileLike(NASA_VIDEO.path)
+        handle = create_demuxer(source=one_stream)
+        _blocks_demuxer_add_stream(handle, 0, "video")
+        _blocks_demuxer_scan(handle, 0)
+
+        two_streams = CountingFileLike(NASA_VIDEO.path)
+        handle = create_demuxer(source=two_streams)
+        _blocks_demuxer_add_stream(handle, 0, "video")
+        _blocks_demuxer_add_stream(handle, 3, "video")
+        first = _blocks_demuxer_scan(handle, 0)
+        after_first_scan = two_streams.bytes_read
+        second = _blocks_demuxer_scan(handle, 3)
+
+        assert two_streams.bytes_read == after_first_scan  # no further I/O
+        assert two_streams.bytes_read == pytest.approx(one_stream.bytes_read, rel=0.01)
+        assert len(first[0]) > 0 and len(second[0]) > 0
+
+    def test_scanning_a_non_video_stream_raises(self):
+        handle = create_demuxer(source=NASA_VIDEO.path)
+        _blocks_demuxer_add_stream(handle, 4, "audio")
+
+        with pytest.raises(RuntimeError, match="Only a video stream can be scanned"):
+            _blocks_demuxer_scan(handle, 4)
 
     # ===== source kinds =====
 


### PR DESCRIPTION
A scan used to read the container once per stream and cache nothing, so indexing two video streams read the file twice and calling scan() twice read it twice again. It is now two phases: one pass over the container buckets the packets of every followed video stream, and the sort plus tensor build happens per stream, the first time that stream's scan is asked for. The I/O is what a scan costs, and it is now paid once. The sorting is paid per-stream (no way around that), but only if / when requested.

Scanning after the first packet has been demuxed raises.

Scanning a non-video stream now raises rather than quietly producing a frame index for something that has no frames or keyframes.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>