### PR TITLE
Multi-stream Python Demuxer

### DIFF
--- a/src/torchcodec/_core/Demuxer.cpp
+++ b/src/torchcodec/_core/Demuxer.cpp
@@ -140,7 +140,7 @@ void Demuxer::find_stream_info() {
 
 void Demuxer::validate_requested_stream(
     int stream_index,
-    AVMediaType media_type) {
+    std::optional<AVMediaType> media_type) {
   int num_streams = static_cast<int>(format_context_->nb_streams);
   STD_TORCH_CHECK(
       stream_index >= 0 && stream_index < num_streams,
@@ -154,42 +154,59 @@ void Demuxer::validate_requested_stream(
 
   AVMediaType stream_media_type =
       format_context_->streams[stream_index]->codecpar->codec_type;
-  STD_TORCH_CHECK(
-      stream_media_type == media_type,
-      "The stream at index ",
-      stream_index,
-      " is not a ",
-      printable(media_type),
-      " stream, it is of type '",
-      printable(stream_media_type),
-      "'.");
+  if (media_type.has_value()) {
+    STD_TORCH_CHECK(
+        stream_media_type == *media_type,
+        "The stream at index ",
+        stream_index,
+        " is not a ",
+        printable(*media_type),
+        " stream, it is of type '",
+        printable(stream_media_type),
+        "'.");
+  } else {
+    STD_TORCH_CHECK(
+        stream_media_type == AVMEDIA_TYPE_VIDEO ||
+            stream_media_type == AVMEDIA_TYPE_AUDIO,
+        "The stream at index ",
+        stream_index,
+        " is of type '",
+        printable(stream_media_type),
+        "', which cannot be decoded. Only audio and video streams can.");
+  }
 }
 
-int Demuxer::add_stream(
+std::pair<int, AVMediaType> Demuxer::add_stream(
     std::optional<int> stream_index,
-    AVMediaType media_type) {
+    std::optional<AVMediaType> media_type) {
+  STD_TORCH_CHECK(
+      stream_index.has_value() || media_type.has_value(),
+      "A stream must be identified either by its index or by its media type.");
   STD_TORCH_CHECK(
       !has_demuxed_,
       "Streams must all be added before the first packet is demuxed: a stream "
       "added now would start at wherever the container currently is, not at "
       "the beginning.");
 
+  int index;
   if (stream_index.has_value()) {
     validate_requested_stream(*stream_index, media_type);
+    index = *stream_index;
+  } else {
+    index = av_find_best_stream(
+        format_context_.get(),
+        *media_type,
+        /*wanted_stream_nb=*/-1,
+        /*related_stream=*/-1,
+        /*decoder_ret=*/nullptr,
+        /*flags=*/0);
+    STD_TORCH_CHECK(
+        index >= 0,
+        "No valid ",
+        printable(*media_type),
+        " stream found in input file.");
   }
 
-  int index = av_find_best_stream(
-      format_context_.get(),
-      media_type,
-      stream_index.value_or(-1),
-      /*related_stream=*/-1,
-      /*decoder_ret=*/nullptr,
-      /*flags=*/0);
-  STD_TORCH_CHECK(
-      index >= 0,
-      "No valid ",
-      printable(media_type),
-      " stream found in input file.");
   STD_TORCH_CHECK(
       std::find(
           active_stream_indices_.begin(),
@@ -201,7 +218,29 @@ int Demuxer::add_stream(
 
   format_context_->streams[index]->discard = AVDISCARD_DEFAULT;
   active_stream_indices_.push_back(index);
-  return index;
+  return {index, format_context_->streams[index]->codecpar->codec_type};
+}
+
+torch::stable::Tensor Demuxer::get_audio_video_stream_indices() const {
+  std::vector<int> indices;
+  for (unsigned int i = 0; i < format_context_->nb_streams; ++i) {
+    AVMediaType type = format_context_->streams[i]->codecpar->codec_type;
+    if (type == AVMEDIA_TYPE_VIDEO || type == AVMEDIA_TYPE_AUDIO) {
+      indices.push_back(static_cast<int>(i));
+    }
+  }
+  STD_TORCH_CHECK(
+      !indices.empty(),
+      "This container has no audio or video stream at all, so there is "
+      "nothing that could be demuxed.");
+
+  auto out = torch::stable::empty(
+      {static_cast<int64_t>(indices.size())}, kStableInt64);
+  auto accessor = mutable_accessor<int64_t, 1>(out);
+  for (size_t i = 0; i < indices.size(); ++i) {
+    accessor[i] = indices[i];
+  }
+  return out;
 }
 
 int Demuxer::resolve_stream_index(std::optional<int> stream_index) const {

--- a/src/torchcodec/_core/Demuxer.h
+++ b/src/torchcodec/_core/Demuxer.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "AVIOContextHolder.h"
@@ -73,10 +74,20 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
 
   explicit Demuxer(std::unique_ptr<AVIOContextHolder> avio_context_holder);
 
-  // Starts following the stream at `stream_index`, or the best stream of
-  // `media_type` when it is left unspecified, and returns its index (which is
-  // absolute across all media types).
-  int add_stream(std::optional<int> stream_index, AVMediaType media_type);
+  // Starts following a stream, and returns its index (absolute across all
+  // media types) together with its media type. Identify it either by
+  // `stream_index`, in which case its media type is looked up and must be audio
+  // or video, or by `media_type` alone, which follows the best stream of that
+  // type. Passing both follows that stream and requires it to be of that type.
+  std::pair<int, AVMediaType> add_stream(
+      std::optional<int> stream_index = std::nullopt,
+      std::optional<AVMediaType> media_type = std::nullopt);
+
+  // int64 [K]: the index of every audio and video stream in the container, in
+  // container order. Anything else - subtitles, data, attachments - is left
+  // out: those can be seen in the metadata but cannot be followed. Raises if
+  // the container has nothing that can be demuxed at all.
+  torch::stable::Tensor get_audio_video_stream_indices() const;
 
   // Returns the next packet of whichever followed stream has one, as a
   // freshly-allocated packet, or a null packet at end of stream. Which stream
@@ -111,7 +122,11 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
 
  private:
   void find_stream_info();
-  void validate_requested_stream(int stream_index, AVMediaType media_type);
+  // Checks `stream_index` is in range, and that it is of `media_type` when one
+  // is given, or audio or video when it isn't.
+  void validate_requested_stream(
+      int stream_index,
+      std::optional<AVMediaType> media_type);
   // The stream a seek is resolved against when the caller doesn't name one:
   // simply the first one that was added. A seek is resolved in a single
   // stream's time base and lands on that stream's keyframes, so which one it is

--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -34,6 +34,7 @@ FFMPEG_OP_NAMES = frozenset(
         "_blocks_create_demuxer_from_bytes",
         "_blocks_create_demuxer_from_file_like",
         "_blocks_demuxer_add_stream",
+        "_blocks_demuxer_get_audio_video_stream_indices",
         "_blocks_demuxer_next_packet",
         "_blocks_demuxer_seek",
         "_blocks_demuxer_scan",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -102,6 +102,9 @@ _blocks_create_demuxer_from_file_like_context = (
     torch.ops.torchcodec_ns._blocks_create_demuxer_from_file_like.default
 )
 _blocks_demuxer_add_stream = torch.ops.torchcodec_ns._blocks_demuxer_add_stream.default
+_blocks_demuxer_get_audio_video_stream_indices = (
+    torch.ops.torchcodec_ns._blocks_demuxer_get_audio_video_stream_indices.default
+)
 _blocks_demuxer_next_packet = (
     torch.ops.torchcodec_ns._blocks_demuxer_next_packet.default
 )

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -79,7 +79,9 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def(
       "_blocks_create_demuxer_from_file_like(int file_like_context) -> Tensor");
   m.def(
-      "_blocks_demuxer_add_stream(Tensor(a!) demuxer, int? stream_index=None, str media_type=\"video\") -> int");
+      "_blocks_demuxer_add_stream(Tensor(a!) demuxer, int? stream_index=None, str? media_type=None) -> (int, str)");
+  m.def(
+      "_blocks_demuxer_get_audio_video_stream_indices(Tensor demuxer) -> Tensor");
   m.def(
       "_blocks_demuxer_next_packet(Tensor(a!) demuxer) -> (Tensor, bool, int)");
   m.def(
@@ -866,12 +868,27 @@ torch::stable::Tensor _blocks_create_demuxer_from_file_like(
   return wrap_pointer_to_tensor<Demuxer>(std::move(demuxer));
 }
 
-int64_t _blocks_demuxer_add_stream(
+torch::stable::Tensor _blocks_demuxer_get_audio_video_stream_indices(
+    torch::stable::Tensor& demuxer) {
+  return unwrap_tensor_to_pointer<Demuxer>(demuxer)
+      ->get_audio_video_stream_indices();
+}
+
+// (stream index, media type) of the stream that is now being followed. The
+// media type comes back so the caller doesn't have to ask for it separately
+// when it identified the stream by index.
+std::tuple<int64_t, std::string> _blocks_demuxer_add_stream(
     torch::stable::Tensor& demuxer,
     std::optional<int64_t> stream_index,
-    std::string media_type) {
-  return unwrap_tensor_to_pointer<Demuxer>(demuxer)->add_stream(
-      to_optional_int(stream_index), parse_media_type(media_type));
+    std::optional<std::string> media_type) {
+  auto [index, type] = unwrap_tensor_to_pointer<Demuxer>(demuxer)->add_stream(
+      to_optional_int(stream_index),
+      media_type.has_value()
+          ? std::optional<AVMediaType>(parse_media_type(*media_type))
+          : std::nullopt);
+  return {
+      static_cast<int64_t>(index),
+      type == AVMEDIA_TYPE_VIDEO ? "video" : "audio"};
 }
 
 // (packet_handle, is_eof, stream_index). On EOF the packet_handle is a dummy
@@ -1683,6 +1700,9 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
       TORCH_BOX(&get_frames_by_pts_in_range_audio));
   m.impl("get_frames_by_pts", TORCH_BOX(&get_frames_by_pts));
   m.impl("_blocks_demuxer_add_stream", TORCH_BOX(&_blocks_demuxer_add_stream));
+  m.impl(
+      "_blocks_demuxer_get_audio_video_stream_indices",
+      TORCH_BOX(&_blocks_demuxer_get_audio_video_stream_indices));
   m.impl(
       "_blocks_demuxer_next_packet", TORCH_BOX(&_blocks_demuxer_next_packet));
   m.impl("_blocks_demuxer_seek", TORCH_BOX(&_blocks_demuxer_seek));

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -17,11 +17,23 @@ API_breakdown_claude_plan.md for the design and rationale.
 
 from ._audio_converter import AudioConverter
 from ._color_converter import ColorConverter
-from ._demuxer import AudioDemuxer, FrameIndex, VideoDemuxer
+from ._demuxer import (
+    AudioDemuxer,
+    # TODO_API_BREAKDOWN DESIGN P1: AudioStream and VideoStream may conflict
+    # with the encoder-side classes of the same name. Maybe that's OK?
+    AudioStream,
+    Demuxer,
+    FrameIndex,
+    VideoDemuxer,
+    VideoStream,
+)
 from ._frame import Packet, RawAudioSamples, RawFrame
 from ._packet_decoder import AudioPacketDecoder, VideoPacketDecoder
 
 __all__ = [
+    "Demuxer",
+    "VideoStream",
+    "AudioStream",
     "VideoDemuxer",
     "AudioDemuxer",
     "VideoPacketDecoder",

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
@@ -17,6 +18,7 @@ from torch import Tensor
 from torchcodec._core._decoder_utils import create_demuxer
 from torchcodec._core.ops import (
     _blocks_demuxer_add_stream,
+    _blocks_demuxer_get_audio_video_stream_indices,
     _blocks_demuxer_next_packet,
     _blocks_demuxer_scan,
     _blocks_demuxer_seek,
@@ -166,37 +168,272 @@ class FrameIndex:
         return self.pts_seconds[self.key_frame_indices]
 
 
-class _BaseDemuxer:
-    """Shared machinery for :class:`VideoDemuxer` and :class:`AudioDemuxer`.
+class _Stream:
+    """One of the streams a :class:`Demuxer` follows.
 
-    Subclasses set ``_media_type``, which is what the stream selection is done
-    against.
+    This is what a packet decoder is built from. It identifies a stream *within*
+    a container that is already open, so no second container is opened, and it
+    keeps that container alive for as long as you hold on to it.
     """
 
     _media_type: str
+
+    # TODO_API_BREAKDOWN DESIGN P1: the index field is public and it's the index
+    # in the container, not the index in the demuxer's .streams field. Maybe
+    # that's OK. We should find a way to make that clear.
+    def __init__(self, demuxer: Demuxer, index: int):
+        self._demuxer = demuxer
+        self.index = index
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(index={self.index})"
+
+
+class VideoStream(_Stream):
+    """A video stream of a :class:`Demuxer`. Build a
+    :class:`VideoPacketDecoder` from it with :meth:`make_decoder` to decode its
+    packets.
+
+    Attributes:
+        index (int): The stream's index within the container, absolute across
+            all media types. This is what a :class:`Packet`'s ``stream_index``
+            is compared against.
+    """
+
+    _media_type = "video"
+
+    def __init__(self, demuxer: Demuxer, index: int):
+        super().__init__(demuxer, index)
+        self._frame_index: FrameIndex | None = None
+
+    def scan(self) -> FrameIndex:
+        """Demux this stream entirely, without decoding it, and return its
+        :class:`FrameIndex`.
+
+        This reads the whole container, and it is the only way to know the
+        stream's exact frame count, timestamps and :term:`keyframe` positions:
+        the container header can be wrong about all of them. The result is
+        cached, and the read is shared: the first scan indexes every video
+        stream the demuxer follows, so scanning a second one costs no I/O.
+
+        **A scan has to happen before any packet is demuxed**, and calling it
+        later raises. That restriction is what keeps it cheap to use: the scan
+        rewinds the demuxer, and since nothing has been fed to a decoder yet,
+        there is nothing to ``reset()`` afterwards.
+        """
+        if self._frame_index is None:
+            pts, duration, is_key_frame, time_base_num, time_base_den = (
+                _blocks_demuxer_scan(self._demuxer._handle, self.index)
+            )
+            self._frame_index = FrameIndex(
+                is_key_frame=is_key_frame,
+                _pts=pts,
+                _duration=duration,
+                _time_base_num=time_base_num,
+                _time_base_den=time_base_den,
+            )
+        return self._frame_index
+
+    def make_decoder(self, device: str | torch.device | None = None):
+        """Build the :class:`VideoPacketDecoder` for this stream.
+
+        ``device`` accepts a string or a ``torch.device``. It defaults to
+        ``None``, which means the current default device (see
+        ``torch.set_default_device``).
+        """
+        # Imported here rather than at module scope: _packet_decoder
+        # imports this module for the types a decoder can be built from,
+        # so a top-level import either way round would be circular.
+        from ._packet_decoder import VideoPacketDecoder
+
+        return VideoPacketDecoder(self, device=device)
+
+
+class AudioStream(_Stream):
+    """An audio stream of a :class:`Demuxer`. Build an
+    :class:`AudioPacketDecoder` from it with :meth:`make_decoder` to decode its
+    packets.
+
+    There is no ``scan()``: a :class:`FrameIndex` describes keyframes and frame
+    positions, and audio has neither.
+
+    Attributes:
+        index (int): The stream's index within the container, absolute across
+            all media types. This is what a :class:`Packet`'s ``stream_index``
+            is compared against.
+    """
+
+    _media_type = "audio"
+
+    def make_decoder(self):
+        """Build the :class:`AudioPacketDecoder` for this stream. Audio is
+        always decoded on the CPU, so there is no ``device`` parameter."""
+        # Imported here rather than at module scope: _packet_decoder
+        # imports this module for the types a decoder can be built from,
+        # so a top-level import either way round would be circular.
+        from ._packet_decoder import AudioPacketDecoder
+
+        return AudioPacketDecoder(self)
+
+
+class Demuxer:
+    """Demux building block: opens a container and yields the compressed
+    :class:`Packet`\\ s of one or more of its streams. Does no decoding.
+
+    This block is passive (it does no threading of its own) and is *not*
+    thread-safe: use one ``Demuxer`` per thread. It streams from the start of
+    the container, or from wherever :meth:`seek` left it.
+
+    Following several streams at once is the point: two single-stream demuxers
+    open the container twice, so decoding both the video and the audio of a file
+    reads it twice. Here they come out of a single pass, interleaved in the
+    order the container stores them, and :attr:`Packet.stream_index` says which
+    stream each one belongs to::
+
+        demuxer = Demuxer("video.mp4", streams=("video", "audio"))
+        video, audio = demuxer.streams
+        decoders = {s.index: s.make_decoder() for s in demuxer.streams}
+
+        for packet in demuxer:
+            for output in decoders[packet.stream_index].decode(packet):
+                ...
+        for decoder in decoders.values():
+            for output in decoder.drain():
+                ...
+
+    Nothing is buffered per stream: a packet is handed to you once, and a caller
+    that wants to consume one stream at a time has to hold on to the other
+    stream's packets itself. How much to keep in flight is a pipeline decision,
+    and it is deliberately left to you.
+
+    Args:
+        source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the media:
+
+            - If ``str``: a local path or a URL to a media file.
+            - If ``Pathlib.path``: a path to a local media file.
+            - If ``bytes`` object or ``torch.Tensor``: the raw encoded data.
+            - If file-like object: we read data from the object on demand. The object must
+              expose the methods `read(self, size: int) -> bytes` and
+              `seek(self, offset: int, whence: int) -> int`. Note that every
+              read has to re-acquire the GIL, so a file-like source doesn't
+              parallelize with the rest of a pipeline as well as the others do.
+        streams: Which streams to follow. Either one selector or a tuple of
+            them, where a selector is:
+
+            - ``"video"``: the :term:`best stream` of that type.
+            - ``"audio"``: likewise.
+            - an ``int``: that stream, by its index within the container,
+              absolute across all media types.
+
+            Plus one standalone form, ``"all"``, which follows every audio and
+            video stream in container order and skips everything else. Defaults
+            to ``"video"``.
+
+            The order is kept: it is the order of :attr:`streams`. Selecting the
+            same stream twice is an error, as is selecting a stream that is
+            neither audio nor video - use ``"all"`` if you want those skipped
+            rather than reported.
+
+            Streams are chosen once, here, and a demuxer never changes which
+            ones it follows.
+
+    Attributes:
+        streams (tuple): The :class:`VideoStream` and :class:`AudioStream`
+            objects being followed, in the order ``streams`` named them.
+    """
 
     def __init__(
         self,
         source: str | Path | bytes | Tensor | io.RawIOBase | io.BufferedReader,
         *,
-        stream_index: int | None = None,
+        streams: str | int | tuple[str | int, ...] = "video",
     ):
         self._handle = create_demuxer(source=source)
-        self._stream_index = _blocks_demuxer_add_stream(
-            self._handle, stream_index, self._media_type
+        self.streams = tuple(
+            self._add_stream(selector) for selector in self._parse_streams(streams)
         )
-        self._frame_index: FrameIndex | None = None
+
+    def _parse_streams(self, streams) -> list[int | str]:
+        """Normalise the ``streams`` argument to a list of selectors, in the
+        order they were given: either a container stream index, or ``"video"`` /
+        ``"audio"`` meaning the best stream of that type.
+
+        Only the *shape* of the argument is checked here. Whether an index
+        exists, whether that stream can be decoded, and whether it was named
+        twice all belong to the demuxer, which checks them as each stream is
+        added.
+        """
+        if streams == "all":
+            return [
+                int(index)
+                for index in _blocks_demuxer_get_audio_video_stream_indices(
+                    self._handle
+                )
+            ]
+
+        if isinstance(streams, (str, int)) or not isinstance(streams, Iterable):
+            streams = (streams,)
+        streams = tuple(streams)
+        if not streams:
+            raise ValueError(
+                "streams is empty, so this demuxer would have nothing to demux."
+            )
+
+        for selector in streams:
+            if selector in ("video", "audio"):
+                continue
+            if selector == "all":
+                raise ValueError(
+                    "streams='all' can only be used on its own, not alongside "
+                    f"other selectors: got {streams!r}."
+                )
+            if not isinstance(selector, int) or isinstance(selector, bool):
+                raise ValueError(
+                    f"Invalid stream selector {selector!r}. Expected 'video', "
+                    "'audio', or an int stream index."
+                )
+        return list(streams)
+
+    def _add_stream(self, selector: int | str) -> _Stream:
+        """Follow the stream a selector names, and wrap it in the class for
+        whichever media type it turns out to be."""
+        index, media_type = _blocks_demuxer_add_stream(
+            self._handle,
+            selector if isinstance(selector, int) else None,
+            selector if isinstance(selector, str) else None,
+        )
+        stream_class = VideoStream if media_type == "video" else AudioStream
+        return stream_class(self, index)
 
     def next_packet(self) -> Packet | None:
-        """Return the next :class:`Packet`, or ``None`` at end of stream."""
-        handle, is_eof, _ = _blocks_demuxer_next_packet(self._handle)
-        return None if is_eof else Packet(handle)
+        """Return the next :class:`Packet`, or ``None`` at end of stream.
 
-    def seek(self, seconds: float) -> None:
+        Packets come out interleaved across the streams being followed, in the
+        order the container stores them; :attr:`Packet.stream_index` says which
+        stream each belongs to.
+        """
+        handle, is_eof, stream_index = _blocks_demuxer_next_packet(self._handle)
+        return None if is_eof else Packet(handle, stream_index)
+
+    def seek(self, seconds: float, *, stream: _Stream | None = None) -> None:
         """Move the demuxer to ``seconds``.
 
-        A seek invalidates whatever the decoder is holding on to, so the
-        packet decoder must be ``reset()`` afterwards.
+        There is one container and one read position, so this moves *every*
+        followed stream, and every decoder fed by this demuxer must be
+        ``reset()`` afterwards - as must any :class:`AudioConverter`, whose
+        resampler state a seek invalidates too.
+
+        ``stream`` says which stream the target is resolved against; it
+        defaults to the first one in ``streams``. This matters because FFmpeg
+        resolves a seek in one stream's time base and lands on *that* stream's
+        :term:`keyframe`\\ s, with the other streams simply resuming from the
+        resulting position - so the seek is exact only for the stream it was
+        resolved against, and another video stream may land mid-GOP and decode
+        garbage until its next keyframe. Name the stream you need to be exact.
+
+        The default is your own ordering rather than, say, the first video
+        stream, so that it doesn't depend on what the container happens to
+        hold.
 
         Where you land, and what comes out first, depends on the medium. For
         video, a decoder can only start on a :term:`keyframe`, so this lands on
@@ -207,7 +444,11 @@ class _BaseDemuxer:
         decoding would give - until it re-primes. Decoding a margin before the
         target and discarding it is the caller's responsibility.
         """
-        _blocks_demuxer_seek(self._handle, float(seconds), self._stream_index)
+        _blocks_demuxer_seek(
+            self._handle,
+            float(seconds),
+            None if stream is None else stream.index,
+        )
 
     def __iter__(self):
         while True:
@@ -217,30 +458,45 @@ class _BaseDemuxer:
             yield packet
 
 
-class VideoDemuxer(_BaseDemuxer):
+class _SingleStreamDemuxer(Demuxer):
+    """Shared machinery for :class:`VideoDemuxer` and :class:`AudioDemuxer`,
+    which are :class:`Demuxer` pinned to one stream of a known media type."""
+
+    _media_type: str
+
+    def __init__(
+        self,
+        source: str | Path | bytes | Tensor | io.RawIOBase | io.BufferedReader,
+        *,
+        stream_index: int | None = None,
+    ):
+        self._handle = create_demuxer(source=source)
+        # The media type is pinned, and an explicit index has to match it.
+        index, _ = _blocks_demuxer_add_stream(
+            self._handle, stream_index, self._media_type
+        )
+        stream_class = VideoStream if self._media_type == "video" else AudioStream
+        self.streams = (stream_class(self, index),)
+
+
+class VideoDemuxer(_SingleStreamDemuxer):
     """Demux building block: opens a container and yields the compressed
     :class:`Packet`\\ s for one video stream. Does no decoding.
 
-    This block is passive (it does no threading of its own) and is *not*
-    thread-safe: use one ``VideoDemuxer`` per thread. It streams from the start
-    of the file, or from wherever :meth:`seek` left it.
-
-    A :class:`VideoDemuxer` also carries the stream configuration used to build a
-    :class:`VideoPacketDecoder`, so that is constructed from a demuxer and no
-    extra container is opened.
+    This is :class:`Demuxer` pinned to a single video stream; see it for
+    everything not specific to that.
 
     Args:
         source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the video:
 
-            - If ``str``: a local path or a URL to a video file.
-            - If ``Pathlib.path``: a path to a local video file.
-            - If ``bytes`` object or ``torch.Tensor``: the raw encoded video data.
-            - If file-like object: we read video data from the object on demand. The object must
+            - If ``str``: a local path or a URL to a media file.
+            - If ``Pathlib.path``: a path to a local media file.
+            - If ``bytes`` object or ``torch.Tensor``: the raw encoded data.
+            - If file-like object: we read data from the object on demand. The object must
               expose the methods `read(self, size: int) -> bytes` and
               `seek(self, offset: int, whence: int) -> int`. Note that every
               read has to re-acquire the GIL, so a file-like source doesn't
               parallelize with the rest of a pipeline as well as the others do.
-
         stream_index (int, optional): Specifies which stream in the video to
             demux packets from. Note that this index is absolute across all
             media types. It must refer to a video stream; use
@@ -252,60 +508,40 @@ class VideoDemuxer(_BaseDemuxer):
 
     def scan(self) -> FrameIndex:
         """Demux the entire stream, without decoding it, and return its
-        :class:`FrameIndex`.
+        :class:`FrameIndex`. See :meth:`VideoStream.scan`."""
+        stream = self.streams[0]
+        assert isinstance(stream, VideoStream)  # mypy: pinned by _media_type
+        return stream.scan()
 
-        This reads the whole file, and it is the only way to know the stream's
-        exact frame count, timestamps and :term:`keyframe` positions: the
-        container header can be wrong about all of them. The result is cached:
-        calling this twice scans once.
-
-        **A scan has to happen before any packet is demuxed**, and calling it
-        later raises. That restriction is what keeps it cheap to use: the scan
-        rewinds the demuxer, and since nothing has been fed to a decoder yet,
-        there is nothing to ``reset()`` afterwards.
-        """
-        if self._frame_index is not None:
-            return self._frame_index
-        pts, duration, is_key_frame, time_base_num, time_base_den = (
-            _blocks_demuxer_scan(self._handle, self._stream_index)
-        )
-        self._frame_index = FrameIndex(
-            is_key_frame=is_key_frame,
-            _pts=pts,
-            _duration=duration,
-            _time_base_num=time_base_num,
-            _time_base_den=time_base_den,
-        )
-        return self._frame_index
+    def make_decoder(self, device: str | torch.device | None = None):
+        """Build the :class:`VideoPacketDecoder` for this stream. See
+        :meth:`VideoStream.make_decoder`."""
+        stream = self.streams[0]
+        assert isinstance(stream, VideoStream)  # mypy: pinned by _media_type
+        return stream.make_decoder(device=device)
 
 
-class AudioDemuxer(_BaseDemuxer):
+class AudioDemuxer(_SingleStreamDemuxer):
     """Demux building block: opens a container and yields the compressed
     :class:`Packet`\\ s for one audio stream. Does no decoding.
 
-    This block is passive (it does no threading of its own) and is *not*
-    thread-safe: use one ``AudioDemuxer`` per thread. It streams from the start
-    of the file, or from wherever :meth:`seek` left it.
-
-    An :class:`AudioDemuxer` also carries the stream configuration used to build
-    an :class:`AudioPacketDecoder`, so that is constructed from a demuxer and
-    no extra container is opened.
+    This is :class:`Demuxer` pinned to a single audio stream; see it for
+    everything not specific to that.
 
     Unlike :class:`VideoDemuxer` there is no ``scan()``: a :class:`FrameIndex`
-    describes keyframes and frame indices, and audio has neither.
+    describes keyframes and frame positions, and audio has neither.
 
     Args:
         source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the audio:
 
-            - If ``str``: a local path or a URL to an audio or video file.
-            - If ``Pathlib.path``: a path to a local audio or video file.
+            - If ``str``: a local path or a URL to a media file.
+            - If ``Pathlib.path``: a path to a local media file.
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded data.
             - If file-like object: we read data from the object on demand. The object must
               expose the methods `read(self, size: int) -> bytes` and
               `seek(self, offset: int, whence: int) -> int`. Note that every
               read has to re-acquire the GIL, so a file-like source doesn't
               parallelize with the rest of a pipeline as well as the others do.
-
         stream_index (int, optional): Specifies which stream in the file to
             demux packets from. Note that this index is absolute across all
             media types. It must refer to an audio stream; use
@@ -314,3 +550,10 @@ class AudioDemuxer(_BaseDemuxer):
     """
 
     _media_type = "audio"
+
+    def make_decoder(self):
+        """Build the :class:`AudioPacketDecoder` for this stream. See
+        :meth:`AudioStream.make_decoder`."""
+        stream = self.streams[0]
+        assert isinstance(stream, AudioStream)  # mypy: pinned by _media_type
+        return stream.make_decoder()

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -32,10 +32,17 @@ class Packet:
     Produced by :class:`VideoDemuxer`, consumed by :class:`VideoPacketDecoder`. It wraps a raw
     pointer, so it is only valid within the process that created it (it cannot
     cross a process boundary).
+
+    Attributes:
+        stream_index (int): The index of the stream this packet belongs to,
+            absolute across all media types. This is what routes a packet to
+            its decoder when it comes out of a :class:`Demuxer` following more
+            than one stream.
     """
 
-    def __init__(self, handle: torch.Tensor):
+    def __init__(self, handle: torch.Tensor, stream_index: int):
         self._handle = handle
+        self.stream_index = stream_index
 
 
 # TODO_API_BREAKDOWN DESIGN P1: API design - the public fields, the class name,

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -20,7 +20,15 @@ from torchcodec._core.ops import (
 )
 
 from .._decoder_utils import convert_device_to_str
-from ._demuxer import AudioDemuxer, VideoDemuxer
+from ._demuxer import (
+    _SingleStreamDemuxer,
+    _Stream,
+    AudioDemuxer,
+    AudioStream,
+    Demuxer,
+    VideoDemuxer,
+    VideoStream,
+)
 from ._frame import Packet, RawAudioSamples, RawFrame
 
 
@@ -38,10 +46,13 @@ class _BasePacketDecoder(Generic[_Decoded]):
     a decoded frame is turned into, which is :meth:`_receive_ready_frames`.
     """
 
-    def __init__(self, demuxer, device_str: str):
+    def __init__(self, source: _Stream | _SingleStreamDemuxer, device_str: str):
+        # Built from a stream, or from one of the single-stream demuxers, which
+        # stands in for the one stream it follows.
+        stream = source.streams[0] if isinstance(source, Demuxer) else source
         self._handle = _blocks_create_packet_decoder(
-            demuxer._handle,
-            stream_index=demuxer._stream_index,
+            stream._demuxer._handle,
+            stream_index=stream.index,
             num_threads=1,
             device=device_str,
         )
@@ -79,6 +90,8 @@ class _BasePacketDecoder(Generic[_Decoded]):
         self._drained = False
 
 
+# TODO_API_BREAKDOWN DESIGN P1: Can/should we explicitly prevent user
+# instanciation of these?
 class VideoPacketDecoder(_BasePacketDecoder[RawFrame]):
     """Decode building block: turns compressed :class:`Packet`\\ s into decoded
     (YUV) :class:`RawFrame`\\ s.
@@ -93,8 +106,12 @@ class VideoPacketDecoder(_BasePacketDecoder[RawFrame]):
     which means the current default device (see ``torch.set_default_device``).
     """
 
-    def __init__(self, demuxer: VideoDemuxer, device: str | torch.device | None = None):
-        super().__init__(demuxer, convert_device_to_str(device))
+    def __init__(
+        self,
+        source: VideoStream | VideoDemuxer,
+        device: str | torch.device | None = None,
+    ):
+        super().__init__(source, convert_device_to_str(device))
 
     def _receive_ready_frames(self) -> list[RawFrame]:
         frames = []
@@ -130,8 +147,8 @@ class AudioPacketDecoder(_BasePacketDecoder[RawAudioSamples]):
     that doesn't change with ``torch.set_default_device``.
     """
 
-    def __init__(self, demuxer: AudioDemuxer):
-        super().__init__(demuxer, "cpu")
+    def __init__(self, source: AudioStream | AudioDemuxer):
+        super().__init__(source, "cpu")
 
     def _receive_ready_frames(self) -> list[RawAudioSamples]:
         samples = []

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -22,12 +22,7 @@ import pytest
 import torch
 from PIL import Image, ImageOps
 from torchcodec import _core, ffmpeg_major_version, FrameBatch
-from torchcodec._core._decoder_utils import create_demuxer
-from torchcodec._core.ops import (
-    _blocks_demuxer_add_stream,
-    _blocks_demuxer_next_packet,
-    _blocks_demuxer_scan,
-)
+from torchcodec._core.ops import _blocks_demuxer_add_stream, _blocks_demuxer_scan
 from torchcodec._frame import Frame
 from torchcodec.decoders import (
     AudioDecoder,
@@ -51,12 +46,15 @@ from torchcodec.decoders._blocks import (
     AudioConverter,
     AudioDemuxer,
     AudioPacketDecoder,
+    AudioStream,
     ColorConverter,
+    Demuxer,
     Packet,
     RawAudioSamples,
     RawFrame,
     VideoDemuxer,
     VideoPacketDecoder,
+    VideoStream,
 )
 from torchcodec.decoders._decoder_utils import _get_cuda_backend
 from torchcodec.decoders._image_decoders import _source_to_tensor
@@ -3664,46 +3662,101 @@ class TestBlocks:
 
         assert num_packets > 0
 
-    def test_ops_follow_several_streams(self):
-        # The Python API for this comes later. At the op level a demuxer can
-        # already follow several streams at once, and it tags every packet with
-        # the stream it came from - which is what routes it to its decoder.
-        handle = create_demuxer(source=NASA_VIDEO.path)
-        video_index = _blocks_demuxer_add_stream(handle, None, "video")
-        audio_index = _blocks_demuxer_add_stream(handle, None, "audio")
-        assert video_index != audio_index
+    # ===== multi-stream Demuxer =====
 
-        counts = {video_index: 0, audio_index: 0}
-        while True:
-            _, is_eof, stream_index = _blocks_demuxer_next_packet(handle)
-            if is_eof:
-                break
-            counts[stream_index] += 1
+    @pytest.mark.parametrize(
+        "streams, expected_indices, expected_types",
+        (
+            ("video", [3], [VideoStream]),
+            ("audio", [4], [AudioStream]),
+            (("video", "audio"), [3, 4], [VideoStream, AudioStream]),
+            # Order is the caller's, not the container's.
+            (("audio", "video"), [4, 3], [AudioStream, VideoStream]),
+            (0, [0], [VideoStream]),
+            ((3, 1), [3, 1], [VideoStream, AudioStream]),
+            # "all" skips the two subtitle streams.
+            ("all", [0, 1, 3, 4], [VideoStream, AudioStream] * 2),
+        ),
+    )
+    def test_stream_selection(self, streams, expected_indices, expected_types):
+        demuxer = Demuxer(NASA_VIDEO.path, streams=streams)
 
-        assert counts[video_index] > 0
-        assert counts[audio_index] > 0
-        # And a single pass really did produce both, rather than one after the
-        # other: the same file demuxed alone gives the same counts.
-        assert counts[video_index] == len(list(VideoDemuxer(NASA_VIDEO.path)))
-        assert counts[audio_index] == len(list(AudioDemuxer(NASA_VIDEO.path)))
+        assert [s.index for s in demuxer.streams] == expected_indices
+        assert [type(s) for s in demuxer.streams] == expected_types
 
-    def test_ops_add_stream_errors(self):
-        handle = create_demuxer(source=NASA_VIDEO.path)
+    def test_stream_selection_defaults_to_best_video(self):
+        assert [s.index for s in Demuxer(NASA_VIDEO.path).streams] == [3]
 
-        # nasa_13013.mp4 carries subtitle streams, which we can demux packets
-        # for but have no decoder for.
-        with pytest.raises(RuntimeError, match="is not a video stream"):
-            _blocks_demuxer_add_stream(handle, 2, "video")
-        with pytest.raises(RuntimeError, match="not a valid stream"):
-            _blocks_demuxer_add_stream(handle, 99, "video")
+    @pytest.mark.parametrize(
+        "streams, match",
+        (
+            ((), "streams is empty"),
+            (("video", "video"), "already being demuxed"),
+            # 3 is the best video stream, so this names it twice.
+            (("video", 3), "already being demuxed"),
+            (2, "which cannot be decoded"),
+            (99, "not a valid stream"),
+            (("all", "audio"), "can only be used on its own"),
+            ("subtitles", "Invalid stream selector"),
+            (1.0, "Invalid stream selector"),
+        ),
+    )
+    def test_stream_selection_errors(self, streams, match):
+        with pytest.raises((ValueError, RuntimeError), match=match):
+            Demuxer(NASA_VIDEO.path, streams=streams)
 
-        _blocks_demuxer_add_stream(handle, 3, "video")
-        with pytest.raises(RuntimeError, match="already being demuxed"):
-            _blocks_demuxer_add_stream(handle, 3, "video")
+    def test_audio_stream_has_no_scan(self):
+        (audio,) = Demuxer(NASA_VIDEO.path, streams="audio").streams
+        assert not hasattr(audio, "scan")
 
-        _blocks_demuxer_next_packet(handle)
+    def test_one_pass_matches_separate_demuxers(self):
+        # The whole point of following both streams at once: what comes out has
+        # to be exactly what two separate demuxers give, sample for sample.
+        demuxer = Demuxer(NASA_VIDEO.path, streams=("video", "audio"))
+        video, audio = demuxer.streams
+        decoders = {s.index: s.make_decoder() for s in demuxer.streams}
+
+        frames, samples = [], []
+        for packet in demuxer:
+            target = frames if packet.stream_index == video.index else samples
+            target += decoders[packet.stream_index].decode(packet)
+        frames += decoders[video.index].drain()
+        samples += decoders[audio.index].drain()
+
+        video_only = VideoDemuxer(NASA_VIDEO.path)
+        expected_frames = list(self._decode(video_only.make_decoder(), video_only))
+        audio_only = AudioDemuxer(NASA_VIDEO.path)
+        expected_samples = list(self._decode(audio_only.make_decoder(), audio_only))
+
+        assert len(frames) == len(expected_frames) > 0
+        assert len(samples) == len(expected_samples) > 0
+        for got, expected in zip(frames, expected_frames):
+            assert got.pts_seconds == expected.pts_seconds
+            torch.testing.assert_close(got.planes, expected.planes, atol=0, rtol=0)
+        for got, expected in zip(samples, expected_samples):
+            assert got.pts_seconds == expected.pts_seconds
+            torch.testing.assert_close(got.data, expected.data, atol=0, rtol=0)
+
+    def test_packets_are_tagged_with_their_stream(self):
+        demuxer = Demuxer(NASA_VIDEO.path, streams=("video", "audio"))
+        video, audio = demuxer.streams
+
+        seen = {video.index: 0, audio.index: 0}
+        for packet in demuxer:
+            seen[packet.stream_index] += 1
+
+        assert seen[video.index] > 0
+        assert seen[audio.index] > 0
+
+    def test_adding_a_stream_after_demuxing_raises(self):
+        # Demuxer follows its streams from construction, so this is only
+        # reachable underneath it - but the demuxer is what enforces it, and a
+        # stream added late would start from wherever the container now is.
+        demuxer = Demuxer(NASA_VIDEO.path)
+        demuxer.next_packet()
+
         with pytest.raises(RuntimeError, match="before the first packet"):
-            _blocks_demuxer_add_stream(handle, 4, "audio")
+            _blocks_demuxer_add_stream(demuxer._handle, 4, "audio")
 
     # The three decode stages, each expressed as a generator that transforms an
     # iterator of inputs into an iterator of outputs. They compose directly (the
@@ -4385,8 +4438,8 @@ class TestBlocks:
                 yield converter.convert(raw_frame)
         # Seeking into the last GOP can leave the codec holding frames until
         # it's told the stream ended.
-        for decoded_frame in decoder.drain():
-            yield converter.convert(decoded_frame)
+        for raw_frame in decoder.drain():
+            yield converter.convert(raw_frame)
 
     def _first_frame_after_seek(self, blocks, seconds):
         return next(self._frames_after_seek(blocks, seconds))
@@ -5058,28 +5111,27 @@ class TestBlocks:
                 return self._file.seek(offset, whence)
 
         one_stream = CountingFileLike(NASA_VIDEO.path)
-        handle = create_demuxer(source=one_stream)
-        _blocks_demuxer_add_stream(handle, 0, "video")
-        _blocks_demuxer_scan(handle, 0)
+        (only,) = Demuxer(one_stream, streams=0).streams
+        only.scan()
 
         two_streams = CountingFileLike(NASA_VIDEO.path)
-        handle = create_demuxer(source=two_streams)
-        _blocks_demuxer_add_stream(handle, 0, "video")
-        _blocks_demuxer_add_stream(handle, 3, "video")
-        first = _blocks_demuxer_scan(handle, 0)
+        left, right = Demuxer(two_streams, streams=(0, 3)).streams
+        first = left.scan()
         after_first_scan = two_streams.bytes_read
-        second = _blocks_demuxer_scan(handle, 3)
+        second = right.scan()
 
         assert two_streams.bytes_read == after_first_scan  # no further I/O
         assert two_streams.bytes_read == pytest.approx(one_stream.bytes_read, rel=0.01)
-        assert len(first[0]) > 0 and len(second[0]) > 0
+        assert len(first) > 0 and len(second) > 0
 
     def test_scanning_a_non_video_stream_raises(self):
-        handle = create_demuxer(source=NASA_VIDEO.path)
-        _blocks_demuxer_add_stream(handle, 4, "audio")
+        # Unreachable through the Python API, where AudioStream simply has no
+        # scan() - which is the point of the stream classes. The check below it
+        # is still worth keeping honest.
+        demuxer = Demuxer(NASA_VIDEO.path, streams="audio")
 
         with pytest.raises(RuntimeError, match="Only a video stream can be scanned"):
-            _blocks_demuxer_scan(handle, 4)
+            _blocks_demuxer_scan(demuxer._handle, demuxer.streams[0].index)
 
     # ===== source kinds =====
 


### PR DESCRIPTION
Adds `Demuxer`, the user-facing half of the multi-stream work. Streams are
chosen once, at construction, and never change:

```python
demuxer = Demuxer("video.mp4", streams=("video", "audio"))
video, audio = demuxer.streams
decoders = {s.index: s.make_decoder() for s in demuxer.streams}

for packet in demuxer:
    for out in decoders[packet.stream_index].decode(packet):
        ...
for decoder in decoders.values():
    for out in decoder.drain():
        ...
```

A selector is `"video"`, `"audio"` or an int container index, alone or in a tuple, plus a standalone `"all"` for every audio and video stream. The order given is the order of `.streams`.

**Streams are objects rather than bare indices** because `scan()` belongs to video and to nothing else: `VideoStream` has it, `AudioStream` simply doesn't, so the rule is enforced by the type rather than by an error message. They're also where `make_decoder()` lives, so a decoder is built from the stream it decodes and no second container is opened.

**`seek()` takes the stream to resolve against.** . It defaults to the first stream in `streams=`:  the user's own ordering.

`VideoDemuxer` and `AudioDemuxer` are now `Demuxer` pinned to one stream, and behave as before. We may or may not keep them in the future.