### PR TITLE
Document the multi-stream demuxer in the blocks tutorial

### DIFF
--- a/benchmarks/bench_blocks.py
+++ b/benchmarks/bench_blocks.py
@@ -15,7 +15,7 @@ import psutil
 import torch
 
 from torchcodec.decoders import VideoDecoder
-from torchcodec.decoders._blocks import ColorConverter, VideoDemuxer, VideoPacketDecoder
+from torchcodec.decoders._blocks import ColorConverter, VideoDemuxer
 
 # Kept minimal on purpose; the filename is derived from exactly these.
 _DURATION_S = 10
@@ -113,7 +113,7 @@ def _consume(frames):
 
 def _decode_sequential(path, device="cpu"):
     demuxer = VideoDemuxer(path)
-    decoder = VideoPacketDecoder(demuxer, device=device)
+    decoder = demuxer.make_decoder(device=device)
     converter = ColorConverter(device=device)
     _consume(_convert(converter, _decode(decoder, _demux(demuxer))))
 
@@ -121,7 +121,7 @@ def _decode_sequential(path, device="cpu"):
 def _decode_prefetch_frames(path, device="cpu"):
     # [demux + decode] on one thread || [color-convert] on another.
     demuxer = VideoDemuxer(path)
-    decoder = VideoPacketDecoder(demuxer, device=device)
+    decoder = demuxer.make_decoder(device=device)
     converter = ColorConverter(device=device)
     frames = prefetch(_decode(decoder, _demux(demuxer)))
     _consume(_convert(converter, frames))
@@ -130,7 +130,7 @@ def _decode_prefetch_frames(path, device="cpu"):
 def _decode_prefetch_packets(path, device="cpu"):
     # [demux] on one thread || [decode + color-convert] on another.
     demuxer = VideoDemuxer(path)
-    decoder = VideoPacketDecoder(demuxer, device=device)
+    decoder = demuxer.make_decoder(device=device)
     converter = ColorConverter(device=device)
     packets = prefetch(_demux(demuxer))
     _consume(_convert(converter, _decode(decoder, packets)))
@@ -139,7 +139,7 @@ def _decode_prefetch_packets(path, device="cpu"):
 def _decode_prefetch_packets_and_frames(path, device="cpu"):
     # [demux] || [decode] || [color-convert], each on its own thread.
     demuxer = VideoDemuxer(path)
-    decoder = VideoPacketDecoder(demuxer, device=device)
+    decoder = demuxer.make_decoder(device=device)
     converter = ColorConverter(device=device)
     packets = prefetch(_demux(demuxer))
     frames = prefetch(_decode(decoder, packets))

--- a/examples/decoding/blocks.py
+++ b/examples/decoding/blocks.py
@@ -31,7 +31,8 @@ threads, accessing raw (YUV) frames, and decoding streams of unknown -
 possibly infinite - length.
 
 Audio works the same way, through ``AudioDemuxer``, ``AudioPacketDecoder`` and
-``AudioConverter``; we come back to it at the end.
+``AudioConverter``; we come back to it at the end, along with ``Demuxer``, which
+gets the audio *and* the video of a container out of a single pass over it.
 """
 
 # %%
@@ -497,6 +498,106 @@ chunks.append(audio_converter.drain())  # don't forget me
 samples = torch.cat([chunk.data for chunk in chunks], dim=1)
 print(f"{samples.shape = }, {samples.dtype = }, "
       f"{chunks[-1].data.shape[1]} samples came out of drain()")
+
+# %%
+# Metadata
+# --------
+#
+# Metadata comes in tiers, and the blocks never merge them. ``demuxer.metadata``
+# is about the container, ``stream.metadata`` is what its header says about one
+# stream, and ``scan()`` is what that stream's packets actually say. A name tells
+# you which tier you are reading, so a header value is never mistaken for an
+# exact one:
+demuxer = VideoDemuxer(video_path)
+(video,) = demuxer.streams
+
+print(f"container: {demuxer.metadata.duration_seconds_from_header}s")
+print(f"header:    {video.metadata.width}x{video.metadata.height}, "
+      f"{video.metadata.num_frames_from_header} frames "
+      f"at {video.metadata.average_fps_from_header} fps")
+print(f"content:   {video.scan().num_frames_from_content} frames "
+      f"at {video.scan().average_fps_from_content} fps")
+
+# %%
+# This is deliberately less helpful than
+# :attr:`~torchcodec.decoders.VideoDecoder.metadata`, which merges the two
+# behind a single ``num_frames`` and picks for you. Here you pick, because
+# knowing which source a number came from is the reason to be at this level.
+#
+# To find out what is in a file before deciding which streams to demux - a
+# demuxer's streams are fixed when you construct it - use
+# ``get_container_metadata()``, which reads the header and no packets. It also
+# reports streams a demuxer cannot follow, such as subtitles.
+from torchcodec.decoders._blocks import get_container_metadata
+
+for stream in get_container_metadata(video_path).streams:
+    print(f"  stream {stream.stream_index}: {stream.codec}")
+
+# %%
+# Video and audio together
+# ------------------------
+#
+# ``VideoDemuxer`` and ``AudioDemuxer`` each open their own container, so
+# decoding both streams of one file reads it twice. ``Demuxer`` follows several
+# streams of a single container instead, in one pass.
+av_path = temp_dir / "av.mp4"
+subprocess.run(
+    [
+        "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+        "-i", str(video_path), "-i", str(audio_path),
+        "-c:v", "copy", "-c:a", "aac", "-shortest", str(av_path),
+    ],
+    check=True,
+)
+
+# %%
+# Which streams to follow is said once, at construction: a selector is
+# ``"video"``, ``"audio"`` or a stream index, and ``demuxer.streams`` comes back
+# in the order you asked for. Each stream builds its own decoder.
+from torchcodec.decoders._blocks import Demuxer
+
+demuxer = Demuxer(av_path, streams=("video", "audio"))
+video_stream, audio_stream = demuxer.streams
+
+decoders = {
+    video_stream.index: video_stream.make_decoder(device=device),
+    audio_stream.index: audio_stream.make_decoder(),
+}
+color_converter = ColorConverter(device=device)
+audio_converter = AudioConverter()
+
+# %%
+# The packets come out interleaved, in the order the container stores them, and
+# ``packet.stream_index`` says which stream each belongs to - so the loop is the
+# single-stream one with a dispatch in the middle. Each decoder is drained at
+# the end, as always.
+frames, chunks = [], []
+for packet in demuxer:
+    outputs = decoders[packet.stream_index].decode(packet)
+    if packet.stream_index == video_stream.index:
+        frames += [color_converter.convert(raw) for raw in outputs]
+    else:
+        chunks += [audio_converter.convert(raw) for raw in outputs]
+
+frames += [color_converter.convert(raw)
+           for raw in decoders[video_stream.index].drain()]
+chunks += [audio_converter.convert(raw)
+           for raw in decoders[audio_stream.index].drain()]
+chunks.append(audio_converter.drain())
+
+samples = torch.cat([chunk.data for chunk in chunks], dim=1)
+print(f"{len(frames)} frames up to {frames[-1].pts_seconds:.2f}s, "
+      f"{samples.shape[1]} samples in one pass over the file")
+
+# %%
+# Nothing is buffered per stream: a packet is handed to you once, and if you
+# want to consume one stream at a time you hold on to the other stream's packets
+# yourself. How many to keep in flight is a decision that belongs to your
+# pipeline, not to the block.
+#
+# ``seek()`` moves the container, so every stream jumps together and every
+# decoder has to be reset, not just one. ``scan()`` lives on the video streams,
+# and has to be called before any packet is demuxed.
 
 # %%
 # .. warning::

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -6,13 +6,21 @@
 
 """Private, experimental building-block decode API.
 
-Exposes the three decode stages -- :class:`VideoDemuxer`,
+Exposes the three decode stages -- :class:`Demuxer`,
 :class:`VideoPacketDecoder`, :class:`ColorConverter` -- as passive, composable,
 GIL-releasing units, so a caller can build its own (threaded) decode pipeline
 and tune how the stages overlap. The blocks do no threading themselves.
 
+A :class:`Demuxer` follows one or more streams of a container, so the video and
+the audio of a file come out of a single pass over it. Metadata is exposed in
+tiers that are never merged: :attr:`Demuxer.metadata` for the container,
+``stream.metadata`` for what the header says about a stream, and
+:meth:`VideoStream.scan` for what its packets actually say. That is the whole
+point of this layer -- it shows you the machinery instead of deciding for you.
+
 This is experimental and private; the API may change. See
-API_breakdown_claude_plan.md for the design and rationale.
+API_breakdown_claude_plan.md and multi_stream_demuxer_design.md for the design
+and rationale.
 """
 
 from ._audio_converter import AudioConverter


### PR DESCRIPTION
Two new sections in the example: metadata, showing the three tiers side by
side so the difference between a header value and a scanned one is visible
rather than described, and video-and-audio-together, showing a Demuxer
getting both out of a single pass.

The benchmark builds its decoder with demuxer.make_decoder(), which is the
documented path now. The module docstring drops the TODO asking how to expose
header metadata, since that is what the previous commit answered.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>