### PR TITLE
Catch a missing reset() after a seek instead of decoding garbage

### DIFF
--- a/src/torchcodec/decoders/_blocks/_audio_converter.py
+++ b/src/torchcodec/decoders/_blocks/_audio_converter.py
@@ -73,6 +73,10 @@ class AudioConverter:
         self._first_frame_pts_seconds: float | None = None
         self._out_sample_rate: int | None = None
         self._num_emitted_samples = 0
+        # The demuxer position these samples come from. See Packet._generation:
+        # a resampler carries state across calls, so a seek invalidates it just
+        # as it invalidates the decoder's.
+        self._generation: int | None = None
 
     def _wrap(self, data) -> AudioSamples:
         assert self._out_sample_rate is not None  # mypy
@@ -100,6 +104,15 @@ class AudioConverter:
         The result may be empty: when resampling, the converter needs the
         following frame before it can emit the tail of this one.
         """
+        if self._generation is None:
+            self._generation = raw_samples._generation
+        elif self._generation != raw_samples._generation:
+            raise RuntimeError(
+                "The demuxer seeked since this converter was last reset(), and "
+                "a resampler carries state across calls, so these samples "
+                "would be resampled against the wrong history. Call reset() on "
+                "every converter fed by that demuxer after a seek."
+            )
         if self._drained:
             raise RuntimeError(
                 "This AudioConverter has been drained. Call reset() to convert "
@@ -139,4 +152,5 @@ class AudioConverter:
         self._drained = False
         self._first_frame_pts_seconds = None
         self._out_sample_rate = None
+        self._generation = None
         self._num_emitted_samples = 0

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -375,6 +375,10 @@ class Demuxer:
         streams: str | int | tuple[str | int, ...] = "video",
     ):
         self._handle = create_demuxer(source=source)
+        # Bumped on every seek and stamped on every packet, so that a decoder
+        # can tell it is being fed packets from a position it was never reset
+        # for. See _BasePacketDecoder.decode().
+        self._generation = 0
         self.streams = tuple(
             self._add_stream(selector) for selector in self._parse_streams(streams)
         )
@@ -454,7 +458,9 @@ class Demuxer:
         stream each belongs to.
         """
         handle, is_eof, stream_index = _blocks_demuxer_next_packet(self._handle)
-        return None if is_eof else Packet(handle, stream_index)
+        if is_eof:
+            return None
+        return Packet(handle, stream_index, generation=self._generation)
 
     def seek(self, seconds: float, *, stream: _Stream | None = None) -> None:
         """Move the demuxer to ``seconds``.
@@ -490,6 +496,7 @@ class Demuxer:
             float(seconds),
             None if stream is None else stream.index,
         )
+        self._generation += 1
 
     def __iter__(self):
         while True:
@@ -512,6 +519,7 @@ class _SingleStreamDemuxer(Demuxer):
         stream_index: int | None = None,
     ):
         self._handle = create_demuxer(source=source)
+        self._generation = 0
         # The media type is pinned, and an explicit index has to match it.
         index, _ = _blocks_demuxer_add_stream(
             self._handle, stream_index, self._media_type

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -40,9 +40,19 @@ class Packet:
             than one stream.
     """
 
-    def __init__(self, handle: torch.Tensor, stream_index: int):
+    def __init__(
+        self,
+        handle: torch.Tensor,
+        stream_index: int,
+        *,
+        generation: int = 0,
+    ):
         self._handle = handle
         self.stream_index = stream_index
+        # Which side of the demuxer's last seek this packet came from. Private:
+        # it exists so a decoder can catch a missing reset(), not for callers to
+        # reason about. See _BasePacketDecoder.decode().
+        self._generation = generation
 
 
 # TODO_API_BREAKDOWN DESIGN P1: API design - the public fields, the class name,
@@ -210,6 +220,8 @@ class RawAudioSamples:
     sample_format: str
     pts_seconds: float
     duration_seconds: float
+    # See Packet._generation.
+    _generation: int = 0
 
     @property
     def num_channels(self) -> int:

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -57,6 +57,10 @@ class _BasePacketDecoder(Generic[_Decoded]):
             device=device_str,
         )
         self._drained = False
+        # The demuxer position these packets come from. None until the first
+        # packet, and again after every reset(), so it is adopted rather than
+        # tracked: the decoder never needs a reference back to the demuxer.
+        self._generation: int | None = None
 
     def _receive_ready_frames(self) -> list[_Decoded]:
         raise NotImplementedError
@@ -69,6 +73,15 @@ class _BasePacketDecoder(Generic[_Decoded]):
                 "This decoder has been drained, and a codec that has been told "
                 "the stream ended ignores any further packet. Create a new "
                 "decoder to decode another stream."
+            )
+        if self._generation is None:
+            self._generation = packet._generation
+        elif self._generation != packet._generation:
+            raise RuntimeError(
+                "The demuxer seeked since this decoder was last reset(), so "
+                "this packet is from a position the codec knows nothing about "
+                "- decoding it would produce plausible-looking garbage. Call "
+                "reset() on every decoder fed by that demuxer after a seek."
             )
         status = _blocks_packet_decoder_send_packet(self._handle, packet._handle)
         if status < 0:
@@ -88,6 +101,7 @@ class _BasePacketDecoder(Generic[_Decoded]):
         demuxer seeked, and after ``drain()``."""
         _blocks_packet_decoder_reset(self._handle)
         self._drained = False
+        self._generation = None
 
 
 # TODO_API_BREAKDOWN DESIGN P1: Can/should we explicitly prevent user
@@ -165,6 +179,9 @@ class AudioPacketDecoder(_BasePacketDecoder[RawAudioSamples]):
                     sample_format=sample_format,
                     pts_seconds=pts_seconds,
                     duration_seconds=duration_seconds,
+                    # Carried onward so AudioConverter can make the same check:
+                    # a seek invalidates the resampler's state too.
+                    _generation=self._generation or 0,
                 )
             )
         return samples

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -4678,13 +4678,13 @@ class TestBlocks:
             assert_frames_equal(got.data, expected.data)
 
     @pytest.mark.parametrize("device", _block_devices())
-    def test_seek_without_reset_yields_stale_frames(self, device):
-        # What goes wrong if you skip the reset: a decoder always holds a few
-        # frames back, and those belong to wherever we were *before* the seek.
-        # It hands those out first, so the frames don't line up with where the
-        # demuxer now is. They aren't corrupt - the landing keyframe gives the
-        # codec a clean slate to decode from - they're just from the wrong
-        # place, and a caller looking at the first frame gets the wrong one.
+    def test_seek_without_reset_raises(self, device):
+        # Skipping the reset used to give you stale frames: a decoder holds a
+        # few back, and those belong to wherever we were *before* the seek. They
+        # aren't corrupt - the landing keyframe gives the codec a clean slate -
+        # they're just from the wrong place, so nothing complains and the caller
+        # silently gets the wrong frames. The packets carry which side of the
+        # seek they came from, so that is now an error instead.
         video_decoder = VideoDecoder(NASA_VIDEO.path, device=device)
         keyframe_index = video_decoder._get_key_frame_indices()[1]
         seconds = video_decoder.get_frame_at(keyframe_index).pts_seconds
@@ -4698,12 +4698,66 @@ class TestBlocks:
                 break
 
         demuxer.seek(seconds)  # ... and no reset()
-        stale = next(frame for packet in demuxer for frame in decoder.decode(packet))
+        with pytest.raises(RuntimeError, match="seeked since this decoder"):
+            next(frame for packet in demuxer for frame in decoder.decode(packet))
 
-        assert stale.pts_seconds < seconds
         # With the reset, that same seek starts exactly where it was asked to.
         blocks = self._make_blocks(NASA_VIDEO.path, device)
         assert self._first_frame_after_seek(blocks, seconds).pts_seconds == seconds
+
+    def test_seek_without_reset_raises_for_every_decoder(self):
+        # The reason this check exists: with several streams there are several
+        # decoders to remember, and forgetting one is invisible otherwise.
+        demuxer = Demuxer(NASA_VIDEO.path, streams=("video", "audio"))
+        video, audio = demuxer.streams
+        decoders = {s.index: s.make_decoder() for s in demuxer.streams}
+
+        # Both decoders have to have seen a packet: one that was never fed
+        # anything has nothing stale to hold on to, and needs no reset.
+        fed = set()
+        for packet in demuxer:
+            decoders[packet.stream_index].decode(packet)
+            fed.add(packet.stream_index)
+            if fed == {video.index, audio.index}:
+                break
+
+        demuxer.seek(4.0)
+        decoders[video.index].reset()  # ... and forget the audio one
+
+        for packet in demuxer:
+            if packet.stream_index == audio.index:
+                with pytest.raises(RuntimeError, match="seeked since this decoder"):
+                    decoders[audio.index].decode(packet)
+                break
+
+    def test_seek_without_converter_reset_raises(self):
+        # A seek invalidates the resampler's state too, and the demuxer cannot
+        # know the converter exists - so the samples carry the check onward.
+        demuxer = AudioDemuxer(NASA_AUDIO_MP3.path)
+        decoder = demuxer.make_decoder()
+        converter = AudioConverter(sample_rate=16_000)
+
+        converted = False
+        for packet in demuxer:
+            for raw in decoder.decode(packet):
+                converter.convert(raw)
+                converted = True
+            if converted:
+                break
+
+        demuxer.seek(2.0)
+        decoder.reset()  # ... and forget the converter
+
+        raws = []
+        for packet in demuxer:
+            raws = decoder.decode(packet)
+            if raws:
+                break
+        with pytest.raises(RuntimeError, match="seeked since this converter"):
+            converter.convert(raws[0])
+
+        converter.reset()
+        converter.convert(raws[0])  # and now it is fine
 
     @pytest.mark.parametrize("video", (NASA_VIDEO, H265_VIDEO, TEST_SRC_2_720P_MPEG4))
     @pytest.mark.parametrize("device", _block_devices())


### PR DESCRIPTION
A seek invalidates every decoder fed by that demuxer, and every audio converter downstream of them. Forgetting one was silent: the codec has a clean keyframe to start from, so it produces plausible frames that simply belong somewhere else. 

The demuxer now counts seeks and stamps the count on every packet. A decoder adopts the count from the first packet it sees, and again after every reset(), and raises if a later packet disagrees. `RawAudioSamples` carries the
count onward so `AudioConverter` makes the same check. The new `_generation` field (the count) is private on both `Packet` and `RawAudioSamples`: it is a correctness mechanism, not something that needs to be publicly exposed.

Deliberately not done: having the demuxer reset the decoders for you. It knows them, since make_decoder() built them, but reaching into them would mutate an AVCodecContext that another thread may be inside decode() on, and the whole premise of these blocks is that the caller composes them across threads. It also could not reach the converters, and half-automatic cleanup is worse than none.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>