### PR TITLE
Expose header metadata from the building blocks

### DIFF
--- a/src/torchcodec/_core/Metadata.cpp
+++ b/src/torchcodec/_core/Metadata.cpp
@@ -5,13 +5,155 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "Metadata.h"
+
+#include <algorithm>
+
+#include "FFMPEGCommon.h"
 #include "StableABICompat.h"
+#include "Transform.h"
 
 extern "C" {
 #include <libavutil/pixdesc.h>
 }
 
 namespace facebook::torchcodec {
+
+namespace {
+int get_best_stream_index(AVFormatContext* format_context, AVMediaType type) {
+  AVCodecOnlyUseForCallingAVFindBestStream av_codec = nullptr;
+  return av_find_best_stream(format_context, type, -1, -1, &av_codec, 0);
+}
+} // namespace
+
+// Builds the container and per-stream metadata that the header describes.
+// Shared by SingleStreamDecoder and by the Demuxer building block, so that both
+// report exactly the same thing.
+ContainerMetadata get_container_metadata_from_format_context(
+    AVFormatContext* format_context) {
+  ContainerMetadata metadata;
+
+  if (format_context->duration > 0) {
+    AVRational default_time_base{1, AV_TIME_BASE};
+    metadata.duration_seconds_from_header =
+        pts_to_seconds(format_context->duration, default_time_base);
+  }
+
+  if (format_context->bit_rate > 0) {
+    metadata.bit_rate = format_context->bit_rate;
+  }
+
+  int best_video_stream =
+      get_best_stream_index(format_context, AVMEDIA_TYPE_VIDEO);
+  if (best_video_stream >= 0) {
+    metadata.best_video_stream_index = best_video_stream;
+  }
+
+  int best_audio_stream =
+      get_best_stream_index(format_context, AVMEDIA_TYPE_AUDIO);
+  if (best_audio_stream >= 0) {
+    metadata.best_audio_stream_index = best_audio_stream;
+  }
+
+  for (unsigned int i = 0; i < format_context->nb_streams; i++) {
+    AVStream* av_stream = format_context->streams[i];
+    StreamMetadata stream_metadata;
+
+    STD_TORCH_CHECK(
+        static_cast<int>(i) == av_stream->index,
+        "Our stream index, " + std::to_string(i) +
+            ", does not match AVStream's index, " +
+            std::to_string(av_stream->index) + ".");
+    stream_metadata.stream_index = i;
+    stream_metadata.codec_name =
+        avcodec_get_name(av_stream->codecpar->codec_id);
+    stream_metadata.media_type = av_stream->codecpar->codec_type;
+    stream_metadata.bit_rate = av_stream->codecpar->bit_rate;
+
+    int64_t frame_count = av_stream->nb_frames;
+    if (frame_count > 0) {
+      stream_metadata.num_frames_from_header = frame_count;
+    }
+
+    if (av_stream->duration > 0 && av_stream->time_base.den > 0) {
+      stream_metadata.duration_seconds_from_header =
+          pts_to_seconds(av_stream->duration, av_stream->time_base);
+    }
+    if (av_stream->start_time != AV_NOPTS_VALUE) {
+      stream_metadata.begin_stream_seconds_from_header =
+          pts_to_seconds(av_stream->start_time, av_stream->time_base);
+    }
+
+    if (av_stream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+      double fps = av_q2d(av_stream->r_frame_rate);
+      if (fps > 0) {
+        stream_metadata.average_fps_from_header = fps;
+      }
+      stream_metadata.rotation = get_rotation_from_stream(av_stream);
+
+      // Report post-rotation dimensions: swap width/height for 90 or -90
+      // degree rotations so metadata matches what the decoder returns.
+      int width = av_stream->codecpar->width;
+      int height = av_stream->codecpar->height;
+      Rotation rotation = rotation_from_degrees(stream_metadata.rotation);
+      // 90° rotations swap dimensions
+      if (rotation == Rotation::CCW90 || rotation == Rotation::CW90) {
+        std::swap(width, height);
+      }
+      stream_metadata.post_rotation_width = width;
+      stream_metadata.post_rotation_height = height;
+
+      stream_metadata.sample_aspect_ratio =
+          av_stream->codecpar->sample_aspect_ratio;
+
+      if (av_stream->codecpar->color_primaries != AVCOL_PRI_UNSPECIFIED) {
+        stream_metadata.color_primaries = av_stream->codecpar->color_primaries;
+      }
+      if (av_stream->codecpar->color_space != AVCOL_SPC_UNSPECIFIED) {
+        stream_metadata.color_space = av_stream->codecpar->color_space;
+      }
+      if (av_stream->codecpar->color_trc != AVCOL_TRC_UNSPECIFIED) {
+        stream_metadata.color_transfer_characteristic =
+            av_stream->codecpar->color_trc;
+      }
+      AVPixelFormat pixel_format =
+          static_cast<AVPixelFormat>(av_stream->codecpar->format);
+      // If the AVPixelFormat is not recognized, we get back nullptr. We have
+      // to make sure we don't initialize a std::string with nullptr. There's
+      // nothing to do on the else branch because we're already using an
+      // optional; it'll just remain empty.
+      const char* raw_pixel_format = av_get_pix_fmt_name(pixel_format);
+      if (raw_pixel_format != nullptr) {
+        stream_metadata.pixel_format = std::string(raw_pixel_format);
+      }
+
+      metadata.num_video_streams++;
+    } else if (av_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      AVSampleFormat format =
+          static_cast<AVSampleFormat>(av_stream->codecpar->format);
+      stream_metadata.sample_rate =
+          static_cast<int64_t>(av_stream->codecpar->sample_rate);
+      stream_metadata.num_channels =
+          static_cast<int64_t>(get_num_channels(av_stream->codecpar));
+
+      // If the AVSampleFormat is not recognized, we get back nullptr. We have
+      // to make sure we don't initialize a std::string with nullptr. There's
+      // nothing to do on the else branch because we're already using an
+      // optional; it'll just remain empty.
+      const char* raw_sample_format = av_get_sample_fmt_name(format);
+      if (raw_sample_format != nullptr) {
+        stream_metadata.sample_format = std::string(raw_sample_format);
+      }
+      metadata.num_audio_streams++;
+    }
+
+    stream_metadata.duration_seconds_from_container =
+        metadata.duration_seconds_from_header;
+
+    metadata.all_stream_metadata.push_back(stream_metadata);
+  }
+
+  return metadata;
+}
 
 std::optional<double> StreamMetadata::get_duration_seconds(
     SeekMode seek_mode) const {

--- a/src/torchcodec/_core/Metadata.h
+++ b/src/torchcodec/_core/Metadata.h
@@ -12,6 +12,7 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/rational.h>
@@ -103,5 +104,10 @@ struct ContainerMetadata {
   // If set, this is the index to the default video stream.
   std::optional<int> best_video_stream_index;
 };
+
+// Builds the container and per-stream metadata that the header describes, from
+// an already-opened and probed AVFormatContext.
+ContainerMetadata get_container_metadata_from_format_context(
+    AVFormatContext* format_context);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -93,136 +93,14 @@ void SingleStreamDecoder::initialize_decoder() {
       "Failed to find stream info: ",
       get_ffmpeg_error_string_from_error_code(status));
 
-  if (format_context_->duration > 0) {
-    AVRational default_time_base{1, AV_TIME_BASE};
-    container_metadata_.duration_seconds_from_header =
-        pts_to_seconds(format_context_->duration, default_time_base);
-  }
-
-  if (format_context_->bit_rate > 0) {
-    container_metadata_.bit_rate = format_context_->bit_rate;
-  }
-
-  int best_video_stream = get_best_stream_index(AVMEDIA_TYPE_VIDEO);
-  if (best_video_stream >= 0) {
-    container_metadata_.best_video_stream_index = best_video_stream;
-  }
-
-  int best_audio_stream = get_best_stream_index(AVMEDIA_TYPE_AUDIO);
-  if (best_audio_stream >= 0) {
-    container_metadata_.best_audio_stream_index = best_audio_stream;
-  }
-
-  for (unsigned int i = 0; i < format_context_->nb_streams; i++) {
-    AVStream* av_stream = format_context_->streams[i];
-    StreamMetadata stream_metadata;
-
-    STD_TORCH_CHECK(
-        static_cast<int>(i) == av_stream->index,
-        "Our stream index, " + std::to_string(i) +
-            ", does not match AVStream's index, " +
-            std::to_string(av_stream->index) + ".");
-    stream_metadata.stream_index = i;
-    stream_metadata.codec_name =
-        avcodec_get_name(av_stream->codecpar->codec_id);
-    stream_metadata.media_type = av_stream->codecpar->codec_type;
-    stream_metadata.bit_rate = av_stream->codecpar->bit_rate;
-
-    int64_t frame_count = av_stream->nb_frames;
-    if (frame_count > 0) {
-      stream_metadata.num_frames_from_header = frame_count;
-    }
-
-    if (av_stream->duration > 0 && av_stream->time_base.den > 0) {
-      stream_metadata.duration_seconds_from_header =
-          pts_to_seconds(av_stream->duration, av_stream->time_base);
-    }
-    if (av_stream->start_time != AV_NOPTS_VALUE) {
-      stream_metadata.begin_stream_seconds_from_header =
-          pts_to_seconds(av_stream->start_time, av_stream->time_base);
-    }
-
-    if (av_stream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-      double fps = av_q2d(av_stream->r_frame_rate);
-      if (fps > 0) {
-        stream_metadata.average_fps_from_header = fps;
-      }
-      stream_metadata.rotation = get_rotation_from_stream(av_stream);
-
-      // Report post-rotation dimensions: swap width/height for 90 or -90
-      // degree rotations so metadata matches what the decoder returns.
-      int width = av_stream->codecpar->width;
-      int height = av_stream->codecpar->height;
-      Rotation rotation = rotation_from_degrees(stream_metadata.rotation);
-      // 90° rotations swap dimensions
-      if (rotation == Rotation::CCW90 || rotation == Rotation::CW90) {
-        std::swap(width, height);
-      }
-      stream_metadata.post_rotation_width = width;
-      stream_metadata.post_rotation_height = height;
-
-      stream_metadata.sample_aspect_ratio =
-          av_stream->codecpar->sample_aspect_ratio;
-
-      if (av_stream->codecpar->color_primaries != AVCOL_PRI_UNSPECIFIED) {
-        stream_metadata.color_primaries = av_stream->codecpar->color_primaries;
-      }
-      if (av_stream->codecpar->color_space != AVCOL_SPC_UNSPECIFIED) {
-        stream_metadata.color_space = av_stream->codecpar->color_space;
-      }
-      if (av_stream->codecpar->color_trc != AVCOL_TRC_UNSPECIFIED) {
-        stream_metadata.color_transfer_characteristic =
-            av_stream->codecpar->color_trc;
-      }
-      AVPixelFormat pixel_format =
-          static_cast<AVPixelFormat>(av_stream->codecpar->format);
-      // If the AVPixelFormat is not recognized, we get back nullptr. We have
-      // to make sure we don't initialize a std::string with nullptr. There's
-      // nothing to do on the else branch because we're already using an
-      // optional; it'll just remain empty.
-      const char* raw_pixel_format = av_get_pix_fmt_name(pixel_format);
-      if (raw_pixel_format != nullptr) {
-        stream_metadata.pixel_format = std::string(raw_pixel_format);
-      }
-
-      container_metadata_.num_video_streams++;
-    } else if (av_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
-      AVSampleFormat format =
-          static_cast<AVSampleFormat>(av_stream->codecpar->format);
-      stream_metadata.sample_rate =
-          static_cast<int64_t>(av_stream->codecpar->sample_rate);
-      stream_metadata.num_channels =
-          static_cast<int64_t>(get_num_channels(av_stream->codecpar));
-
-      // If the AVSampleFormat is not recognized, we get back nullptr. We have
-      // to make sure we don't initialize a std::string with nullptr. There's
-      // nothing to do on the else branch because we're already using an
-      // optional; it'll just remain empty.
-      const char* raw_sample_format = av_get_sample_fmt_name(format);
-      if (raw_sample_format != nullptr) {
-        stream_metadata.sample_format = std::string(raw_sample_format);
-      }
-      container_metadata_.num_audio_streams++;
-    }
-
-    stream_metadata.duration_seconds_from_container =
-        container_metadata_.duration_seconds_from_header;
-
-    container_metadata_.all_stream_metadata.push_back(stream_metadata);
-  }
+  container_metadata_ =
+      get_container_metadata_from_format_context(format_context_.get());
 
   if (seek_mode_ == SeekMode::exact) {
     scan_file_and_update_metadata_and_index();
   }
 
   initialized_ = true;
-}
-
-int SingleStreamDecoder::get_best_stream_index(AVMediaType media_type) {
-  AVCodecOnlyUseForCallingAVFindBestStream av_codec = nullptr;
-  int stream_index = av_find_best_stream(
-      format_context_.get(), media_type, -1, -1, &av_codec, 0);
-  return stream_index;
 }
 
 // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -333,7 +333,6 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
   // for more details about the heuristics.
   // Returns the key frame index of the presentation timestamp using FFMPEG's
   // index. Note that this index may be truncated for some files.
-  int get_best_stream_index(AVMediaType media_type);
 
   // --------------------------------------------------------------------------
   // VALIDATION UTILS

--- a/src/torchcodec/_core/_ffmpeg_op_names.py
+++ b/src/torchcodec/_core/_ffmpeg_op_names.py
@@ -35,6 +35,8 @@ FFMPEG_OP_NAMES = frozenset(
         "_blocks_create_demuxer_from_file_like",
         "_blocks_demuxer_add_stream",
         "_blocks_demuxer_get_audio_video_stream_indices",
+        "_blocks_demuxer_container_json_metadata",
+        "_blocks_demuxer_stream_json_metadata",
         "_blocks_demuxer_next_packet",
         "_blocks_demuxer_seek",
         "_blocks_demuxer_scan",

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -105,6 +105,12 @@ _blocks_demuxer_add_stream = torch.ops.torchcodec_ns._blocks_demuxer_add_stream.
 _blocks_demuxer_get_audio_video_stream_indices = (
     torch.ops.torchcodec_ns._blocks_demuxer_get_audio_video_stream_indices.default
 )
+_blocks_demuxer_container_json_metadata = (
+    torch.ops.torchcodec_ns._blocks_demuxer_container_json_metadata.default
+)
+_blocks_demuxer_stream_json_metadata = (
+    torch.ops.torchcodec_ns._blocks_demuxer_stream_json_metadata.default
+)
 _blocks_demuxer_next_packet = (
     torch.ops.torchcodec_ns._blocks_demuxer_next_packet.default
 )

--- a/src/torchcodec/_core/_metadata.py
+++ b/src/torchcodec/_core/_metadata.py
@@ -10,6 +10,7 @@ import json
 import pathlib
 from dataclasses import dataclass
 from fractions import Fraction
+from typing import Any
 
 import torch
 from torchcodec._core.ops import (
@@ -206,37 +207,40 @@ class AudioStreamMetadata(AudioStreamHeaderMetadata):
 
 
 @dataclass
-class ContainerMetadata:
+class DemuxerMetadata:
+    """Container-level metadata, as reported by the header.
+
+    This is what a demuxer can say about the container itself. Everything about
+    the streams it follows is on those streams; the full list of streams in the
+    file, including the ones that cannot be followed, comes from
+    ``get_container_metadata()`` instead.
+    """
+
     duration_seconds_from_header: float | None
+    """Duration of the container, in seconds, obtained from the header (float
+    or None). Some containers carry a duration only here, with their streams
+    reporting none, which is why this is worth having separately."""
     bit_rate_from_header: float | None
+    """Overall bit rate of the container (float or None). Not the sum of the
+    streams' bit rates: it includes muxing overhead."""
     best_video_stream_index: int | None
+    """Index of the stream FFmpeg considers the best video one (int or None)."""
     best_audio_stream_index: int | None
+    """Index of the stream FFmpeg considers the best audio one (int or None)."""
 
+    def __repr__(self):
+        s = self.__class__.__name__ + ":\n"
+        for field in dataclasses.fields(self):
+            s += f"{SPACES}{field.name}: {getattr(self, field.name)}\n"
+        return s
+
+
+@dataclass
+class ContainerMetadata(DemuxerMetadata):
     streams: list[StreamMetadata]
-
-    @property
-    def duration_seconds(self) -> float | None:
-        raise NotImplementedError("Decide on logic and implement this!")
-
-    @property
-    def bit_rate(self) -> float | None:
-        raise NotImplementedError("Decide on logic and implement this!")
-
-    @property
-    def best_video_stream(self) -> VideoStreamMetadata:
-        if self.best_video_stream_index is None:
-            raise ValueError("The best video stream is unknown.")
-        metadata = self.streams[self.best_video_stream_index]
-        assert isinstance(metadata, VideoStreamMetadata)  # mypy <3
-        return metadata
-
-    @property
-    def best_audio_stream(self) -> AudioStreamMetadata:
-        if self.best_audio_stream_index is None:
-            raise ValueError("The best audio stream is unknown.")
-        metadata = self.streams[self.best_audio_stream_index]
-        assert isinstance(metadata, AudioStreamMetadata)  # mypy <3
-        return metadata
+    """One entry per stream in the file, indexed by stream index. Streams that
+    are neither video nor audio (subtitles, data) are plain
+    :class:`StreamMetadata`: you can see them, you cannot decode them."""
 
 
 def _get_optional_par_fraction(stream_dict):
@@ -251,6 +255,49 @@ def _get_optional_par_fraction(stream_dict):
 
 # TODO-AUDIO: This is user-facing. Should this just be `get_metadata`, without
 # the "container" name in it? Same below.
+def _stream_metadata_from_dict(stream_dict: dict, stream_index: int) -> StreamMetadata:
+    """Build the header-tier metadata for one stream, from its JSON dict.
+
+    Shared by the decoder path, which then adds the content-derived and
+    computed fields, and by the building-block path, which has only this tier.
+    """
+    # Values come out of untyped JSON, so this is Any as far as mypy can tell.
+    header_meta: dict[str, Any] = dict(
+        duration_seconds_from_header=stream_dict.get("durationSecondsFromHeader"),
+        bit_rate=stream_dict.get("bitRate"),
+        begin_stream_seconds_from_header=stream_dict.get(
+            "beginStreamSecondsFromHeader"
+        ),
+        codec=stream_dict.get("codec"),
+        stream_index=stream_index,
+    )
+    if stream_dict["mediaType"] == "video":
+        return VideoStreamHeaderMetadata(
+            width=stream_dict.get("width"),
+            height=stream_dict.get("height"),
+            num_frames_from_header=stream_dict.get("numFramesFromHeader"),
+            average_fps_from_header=stream_dict.get("averageFpsFromHeader"),
+            pixel_aspect_ratio=_get_optional_par_fraction(stream_dict),
+            rotation=stream_dict.get("rotation"),
+            color_primaries=stream_dict.get("colorPrimaries"),
+            color_space=stream_dict.get("colorSpace"),
+            color_transfer_characteristic=stream_dict.get(
+                "colorTransferCharacteristic"
+            ),
+            pixel_format=stream_dict.get("pixelFormat"),
+            **header_meta,
+        )
+    if stream_dict["mediaType"] == "audio":
+        return AudioStreamHeaderMetadata(
+            sample_rate=stream_dict.get("sampleRate"),
+            num_channels=stream_dict.get("numChannels"),
+            sample_format=stream_dict.get("sampleFormat"),
+            **header_meta,
+        )
+    # Neither video nor audio. Could be e.g. subtitles: visible, not decodable.
+    return StreamMetadata(**header_meta)
+
+
 def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
     """Return container metadata from a decoder.
 

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -82,6 +82,9 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
       "_blocks_demuxer_add_stream(Tensor(a!) demuxer, int? stream_index=None, str? media_type=None) -> (int, str)");
   m.def(
       "_blocks_demuxer_get_audio_video_stream_indices(Tensor demuxer) -> Tensor");
+  m.def("_blocks_demuxer_container_json_metadata(Tensor demuxer) -> str");
+  m.def(
+      "_blocks_demuxer_stream_json_metadata(Tensor demuxer, int stream_index) -> str");
   m.def(
       "_blocks_demuxer_next_packet(Tensor(a!) demuxer) -> (Tensor, bool, int)");
   m.def(
@@ -1238,65 +1241,20 @@ std::string get_json_metadata(torch::stable::Tensor& decoder) {
 }
 
 // Get the container metadata as a string.
-std::string get_container_json_metadata(torch::stable::Tensor& decoder) {
-  auto video_decoder = unwrap_tensor_to_get_decoder(decoder);
-
-  auto container_metadata = video_decoder->get_container_metadata();
-
-  std::map<std::string, std::string> map;
-
-  if (container_metadata.duration_seconds_from_header.has_value()) {
-    map["durationSecondsFromHeader"] =
-        fmt::to_string(*container_metadata.duration_seconds_from_header);
-  }
-
-  if (container_metadata.bit_rate.has_value()) {
-    map["bitRate"] = fmt::to_string(*container_metadata.bit_rate);
-  }
-
-  if (container_metadata.best_video_stream_index.has_value()) {
-    map["bestVideoStreamIndex"] =
-        std::to_string(*container_metadata.best_video_stream_index);
-  }
-  if (container_metadata.best_audio_stream_index.has_value()) {
-    map["bestAudioStreamIndex"] =
-        std::to_string(*container_metadata.best_audio_stream_index);
-  }
-
-  map["numStreams"] =
-      std::to_string(container_metadata.all_stream_metadata.size());
-
-  return map_to_json(map);
-}
-
-// Get the stream metadata as a string.
-std::string get_stream_json_metadata(
-    torch::stable::Tensor& decoder,
-    int64_t stream_index) {
-  auto video_decoder = unwrap_tensor_to_get_decoder(decoder);
-  auto all_stream_metadata =
-      video_decoder->get_container_metadata().all_stream_metadata;
-  STABLE_CHECK_INDEX(
-      stream_index >= 0 &&
-          stream_index < static_cast<int64_t>(all_stream_metadata.size()),
-      "stream_index out of bounds: " + std::to_string(stream_index));
-
-  auto stream_metadata = all_stream_metadata[stream_index];
-  auto seek_mode = video_decoder->get_seek_mode();
-  int active_stream_index = video_decoder->get_active_stream_index();
-
-  std::map<std::string, std::string> map;
-
+namespace {
+// The half of a stream's metadata that comes from the container header. Shared
+// by get_stream_json_metadata, which then adds the content-derived and
+// fallback-computed fields, and by the Demuxer building block, which has only
+// this half to report.
+void write_header_based_metadata(
+    std::map<std::string, std::string>& map,
+    const StreamMetadata& stream_metadata) {
   if (stream_metadata.duration_seconds_from_header.has_value()) {
     map["durationSecondsFromHeader"] =
         fmt::to_string(*stream_metadata.duration_seconds_from_header);
   }
   if (stream_metadata.bit_rate.has_value()) {
     map["bitRate"] = fmt::to_string(*stream_metadata.bit_rate);
-  }
-  if (stream_metadata.num_frames_from_content.has_value()) {
-    map["numFramesFromContent"] =
-        std::to_string(*stream_metadata.num_frames_from_content);
   }
   if (stream_metadata.num_frames_from_header.has_value()) {
     map["numFramesFromHeader"] =
@@ -1305,14 +1263,6 @@ std::string get_stream_json_metadata(
   if (stream_metadata.begin_stream_seconds_from_header.has_value()) {
     map["beginStreamSecondsFromHeader"] =
         fmt::to_string(*stream_metadata.begin_stream_seconds_from_header);
-  }
-  if (stream_metadata.begin_stream_pts_seconds_from_content.has_value()) {
-    map["beginStreamSecondsFromContent"] =
-        fmt::to_string(*stream_metadata.begin_stream_pts_seconds_from_content);
-  }
-  if (stream_metadata.end_stream_pts_seconds_from_content.has_value()) {
-    map["endStreamSecondsFromContent"] =
-        fmt::to_string(*stream_metadata.end_stream_pts_seconds_from_content);
   }
   if (stream_metadata.codec_name.has_value()) {
     map["codec"] = quote_value(stream_metadata.codec_name.value());
@@ -1363,6 +1313,116 @@ std::string get_stream_json_metadata(
     map["mediaType"] = quote_value("audio");
   } else {
     map["mediaType"] = quote_value("other");
+  }
+}
+} // namespace
+
+// The container header, as the Demuxer building block reports it: container
+// facts plus one entry per stream, and nothing derived from content. The
+// building blocks never merge the two, so a caller always knows which of the
+// two sources a number came from.
+std::string _blocks_demuxer_container_json_metadata(
+    torch::stable::Tensor& demuxer) {
+  ContainerMetadata metadata = get_container_metadata_from_format_context(
+      unwrap_tensor_to_pointer<Demuxer>(demuxer)->format_context().get());
+
+  std::map<std::string, std::string> map;
+  if (metadata.duration_seconds_from_header.has_value()) {
+    map["durationSecondsFromHeader"] =
+        fmt::to_string(*metadata.duration_seconds_from_header);
+  }
+  if (metadata.bit_rate.has_value()) {
+    map["bitRate"] = fmt::to_string(*metadata.bit_rate);
+  }
+  if (metadata.best_video_stream_index.has_value()) {
+    map["bestVideoStreamIndex"] =
+        std::to_string(*metadata.best_video_stream_index);
+  }
+  if (metadata.best_audio_stream_index.has_value()) {
+    map["bestAudioStreamIndex"] =
+        std::to_string(*metadata.best_audio_stream_index);
+  }
+  map["numStreams"] = std::to_string(metadata.all_stream_metadata.size());
+  return map_to_json(map);
+}
+
+std::string _blocks_demuxer_stream_json_metadata(
+    torch::stable::Tensor& demuxer,
+    int64_t stream_index) {
+  ContainerMetadata metadata = get_container_metadata_from_format_context(
+      unwrap_tensor_to_pointer<Demuxer>(demuxer)->format_context().get());
+  STABLE_CHECK_INDEX(
+      stream_index >= 0 &&
+          stream_index <
+              static_cast<int64_t>(metadata.all_stream_metadata.size()),
+      "stream_index out of bounds: " + std::to_string(stream_index));
+
+  std::map<std::string, std::string> map;
+  write_header_based_metadata(map, metadata.all_stream_metadata[stream_index]);
+  return map_to_json(map);
+}
+
+std::string get_container_json_metadata(torch::stable::Tensor& decoder) {
+  auto video_decoder = unwrap_tensor_to_get_decoder(decoder);
+
+  auto container_metadata = video_decoder->get_container_metadata();
+
+  std::map<std::string, std::string> map;
+
+  if (container_metadata.duration_seconds_from_header.has_value()) {
+    map["durationSecondsFromHeader"] =
+        fmt::to_string(*container_metadata.duration_seconds_from_header);
+  }
+
+  if (container_metadata.bit_rate.has_value()) {
+    map["bitRate"] = fmt::to_string(*container_metadata.bit_rate);
+  }
+
+  if (container_metadata.best_video_stream_index.has_value()) {
+    map["bestVideoStreamIndex"] =
+        std::to_string(*container_metadata.best_video_stream_index);
+  }
+  if (container_metadata.best_audio_stream_index.has_value()) {
+    map["bestAudioStreamIndex"] =
+        std::to_string(*container_metadata.best_audio_stream_index);
+  }
+
+  map["numStreams"] =
+      std::to_string(container_metadata.all_stream_metadata.size());
+
+  return map_to_json(map);
+}
+
+// Get the stream metadata as a string.
+std::string get_stream_json_metadata(
+    torch::stable::Tensor& decoder,
+    int64_t stream_index) {
+  auto video_decoder = unwrap_tensor_to_get_decoder(decoder);
+  auto all_stream_metadata =
+      video_decoder->get_container_metadata().all_stream_metadata;
+  STABLE_CHECK_INDEX(
+      stream_index >= 0 &&
+          stream_index < static_cast<int64_t>(all_stream_metadata.size()),
+      "stream_index out of bounds: " + std::to_string(stream_index));
+
+  auto stream_metadata = all_stream_metadata[stream_index];
+  auto seek_mode = video_decoder->get_seek_mode();
+  int active_stream_index = video_decoder->get_active_stream_index();
+
+  std::map<std::string, std::string> map;
+
+  write_header_based_metadata(map, stream_metadata);
+  if (stream_metadata.num_frames_from_content.has_value()) {
+    map["numFramesFromContent"] =
+        std::to_string(*stream_metadata.num_frames_from_content);
+  }
+  if (stream_metadata.begin_stream_pts_seconds_from_content.has_value()) {
+    map["beginStreamSecondsFromContent"] =
+        fmt::to_string(*stream_metadata.begin_stream_pts_seconds_from_content);
+  }
+  if (stream_metadata.end_stream_pts_seconds_from_content.has_value()) {
+    map["endStreamSecondsFromContent"] =
+        fmt::to_string(*stream_metadata.end_stream_pts_seconds_from_content);
   }
 
   // Check whether content-based metadata is available for this stream.
@@ -1703,6 +1763,12 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl(
       "_blocks_demuxer_get_audio_video_stream_indices",
       TORCH_BOX(&_blocks_demuxer_get_audio_video_stream_indices));
+  m.impl(
+      "_blocks_demuxer_container_json_metadata",
+      TORCH_BOX(&_blocks_demuxer_container_json_metadata));
+  m.impl(
+      "_blocks_demuxer_stream_json_metadata",
+      TORCH_BOX(&_blocks_demuxer_stream_json_metadata));
   m.impl(
       "_blocks_demuxer_next_packet", TORCH_BOX(&_blocks_demuxer_next_packet));
   m.impl("_blocks_demuxer_seek", TORCH_BOX(&_blocks_demuxer_seek));

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -24,6 +24,7 @@ from ._demuxer import (
     AudioStream,
     Demuxer,
     FrameIndex,
+    get_container_metadata,
     VideoDemuxer,
     VideoStream,
 )
@@ -32,6 +33,7 @@ from ._packet_decoder import AudioPacketDecoder, VideoPacketDecoder
 
 __all__ = [
     "Demuxer",
+    "get_container_metadata",
     "VideoStream",
     "AudioStream",
     "VideoDemuxer",
@@ -45,9 +47,3 @@ __all__ = [
     "RawAudioSamples",
     "FrameIndex",
 ]
-
-# TODO_API_BREAKDOWN FEAT P1 we probably need a way to expose the *header*
-# metadata - something that would avoid using VideoDecoder? VideoDemuxer.scan()
-# covers the content-derived half of that. Audio makes this more pressing:
-# there is no scan() there, so sample_rate / num_channels / sample_format are
-# only reachable through AudioDecoder today.

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import io
+import json
 from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
@@ -16,12 +17,19 @@ import torch
 from torch import Tensor
 
 from torchcodec._core._decoder_utils import create_demuxer
+from torchcodec._core._metadata import (
+    _stream_metadata_from_dict,
+    ContainerMetadata,
+    DemuxerMetadata,
+)
 from torchcodec._core.ops import (
     _blocks_demuxer_add_stream,
+    _blocks_demuxer_container_json_metadata,
     _blocks_demuxer_get_audio_video_stream_indices,
     _blocks_demuxer_next_packet,
     _blocks_demuxer_scan,
     _blocks_demuxer_seek,
+    _blocks_demuxer_stream_json_metadata,
 )
 
 from ._frame import Packet
@@ -184,6 +192,24 @@ class _Stream:
     def __init__(self, demuxer: Demuxer, index: int):
         self._demuxer = demuxer
         self.index = index
+
+    @cached_property
+    def metadata(self):
+        """What the container header says about this stream, and nothing more.
+
+        Content-derived values never appear here: they only exist after an
+        explicit :meth:`VideoStream.scan`, and they live on the
+        :class:`FrameIndex` it returns. So ``metadata.num_frames_from_header``
+        is the header's claim, which may be wrong, and
+        ``scan().num_frames_from_content`` is the exact answer - the name says
+        which one you are reading.
+        """
+        return _stream_metadata_from_dict(
+            json.loads(
+                _blocks_demuxer_stream_json_metadata(self._demuxer._handle, self.index)
+            ),
+            self.index,
+        )
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(index={self.index})"
@@ -352,6 +378,21 @@ class Demuxer:
         self.streams = tuple(
             self._add_stream(selector) for selector in self._parse_streams(streams)
         )
+
+    @cached_property
+    def metadata(self) -> DemuxerMetadata:
+        """What the container header says about the container itself.
+
+        Not about its streams: those are described by
+        ``demuxer.streams[i].metadata``, and there is deliberately only one way
+        to reach each fact. What is here is what no stream can tell you - most
+        usefully ``duration_seconds_from_header``, which some containers carry
+        only at this level, with their streams reporting no duration at all.
+
+        To see every stream in a file, including the ones a demuxer cannot
+        follow, use :func:`get_container_metadata`.
+        """
+        return DemuxerMetadata(**_container_fields(self._handle))
 
     def _parse_streams(self, streams) -> list[int | str]:
         """Normalise the ``streams`` argument to a list of selectors, in the
@@ -557,3 +598,41 @@ class AudioDemuxer(_SingleStreamDemuxer):
         stream = self.streams[0]
         assert isinstance(stream, AudioStream)  # mypy: pinned by _media_type
         return stream.make_decoder()
+
+
+def _container_fields(handle: Tensor) -> dict:
+    container_dict = json.loads(_blocks_demuxer_container_json_metadata(handle))
+    return dict(
+        duration_seconds_from_header=container_dict.get("durationSecondsFromHeader"),
+        bit_rate_from_header=container_dict.get("bitRate"),
+        best_video_stream_index=container_dict.get("bestVideoStreamIndex"),
+        best_audio_stream_index=container_dict.get("bestAudioStreamIndex"),
+    )
+
+
+def get_container_metadata(
+    source: str | Path | bytes | Tensor | io.RawIOBase | io.BufferedReader,
+) -> ContainerMetadata:
+    """Describe a container and every stream in it, without decoding anything.
+
+    This opens the source and reads its header - no packet is demuxed - so it is
+    what you reach for before you know what a file contains and therefore which
+    streams to ask a :class:`Demuxer` for. It reports streams that a demuxer
+    cannot follow, such as subtitles, as plain
+    :class:`~torchcodec._core._metadata.StreamMetadata`.
+
+    Note this opens the source, and constructing a :class:`Demuxer` afterwards
+    opens it again. That second open is a header probe, not a read of the file,
+    and it is the price of a demuxer whose streams are fixed at construction and
+    never change afterwards.
+    """
+    handle = create_demuxer(source=source)
+    container_dict = json.loads(_blocks_demuxer_container_json_metadata(handle))
+    streams = [
+        _stream_metadata_from_dict(
+            json.loads(_blocks_demuxer_stream_json_metadata(handle, stream_index)),
+            stream_index,
+        )
+        for stream_index in range(int(container_dict["numStreams"]))
+    ]
+    return ContainerMetadata(**_container_fields(handle), streams=streams)

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -49,6 +49,7 @@ from torchcodec.decoders._blocks import (
     AudioStream,
     ColorConverter,
     Demuxer,
+    get_container_metadata,
     Packet,
     RawAudioSamples,
     RawFrame,
@@ -3747,6 +3748,114 @@ class TestBlocks:
 
         assert seen[video.index] > 0
         assert seen[audio.index] > 0
+
+    # ===== metadata =====
+
+    def test_stream_metadata_matches_the_decoders(self):
+        # The blocks report the header tier and nothing else, but where a field
+        # exists on both sides it has to say the same thing - same name, same
+        # value.
+        demuxer = Demuxer(NASA_VIDEO.path, streams=("video", "audio"))
+        video, audio = demuxer.streams
+
+        expected_video = VideoDecoder(NASA_VIDEO.path).metadata
+        for field in (
+            "stream_index",
+            "codec",
+            "bit_rate",
+            "duration_seconds_from_header",
+            "begin_stream_seconds_from_header",
+            "width",
+            "height",
+            "num_frames_from_header",
+            "average_fps_from_header",
+            "pixel_aspect_ratio",
+            "rotation",
+            "color_primaries",
+            "color_space",
+            "color_transfer_characteristic",
+            "pixel_format",
+        ):
+            assert getattr(video.metadata, field) == getattr(expected_video, field)
+
+        expected_audio = AudioDecoder(NASA_VIDEO.path).metadata
+        for field in ("sample_rate", "num_channels", "sample_format", "codec"):
+            assert getattr(audio.metadata, field) == getattr(expected_audio, field)
+
+    def test_stream_metadata_has_no_content_tier(self):
+        # The whole point: nothing here is derived from content, so nothing
+        # here silently changes meaning depending on whether a scan happened.
+        (video,) = Demuxer(NASA_VIDEO.path).streams
+
+        for field in (
+            "num_frames_from_content",
+            "begin_stream_seconds_from_content",
+            "end_stream_seconds_from_content",
+            "num_frames",
+            "average_fps",
+            "duration_seconds",
+            "begin_stream_seconds",
+            "end_stream_seconds",
+        ):
+            assert not hasattr(video.metadata, field), field
+
+        # Scanning doesn't change that; the exact answers live on the index.
+        index = video.scan()
+        assert not hasattr(video.metadata, "num_frames")
+        assert video.metadata.num_frames_from_header == index.num_frames_from_content
+
+    def test_demuxer_metadata_has_no_stream_list(self):
+        demuxer = Demuxer(NASA_VIDEO.path)
+        # Older FFmpeg reports this container's duration differently.
+        expected_duration = 16.57 if ffmpeg_major_version <= 5 else 13.056
+
+        assert demuxer.metadata.duration_seconds_from_header == pytest.approx(
+            expected_duration
+        )
+        assert demuxer.metadata.best_video_stream_index == 3
+        assert demuxer.metadata.best_audio_stream_index == 4
+        # Streams are described by demuxer.streams[i].metadata, and only there.
+        assert not hasattr(demuxer.metadata, "streams")
+
+    def test_get_container_metadata(self):
+        metadata = get_container_metadata(NASA_VIDEO.path)
+        # Older FFmpeg reports this container's duration differently.
+        expected_duration = 16.57 if ffmpeg_major_version <= 5 else 13.056
+
+        assert metadata.duration_seconds_from_header == pytest.approx(expected_duration)
+        assert metadata.best_video_stream_index == 3
+        # Every stream, including the two subtitle ones a demuxer can't follow.
+        assert [type(s).__name__ for s in metadata.streams] == [
+            "VideoStreamHeaderMetadata",
+            "AudioStreamHeaderMetadata",
+            "StreamMetadata",
+            "VideoStreamHeaderMetadata",
+            "AudioStreamHeaderMetadata",
+            "StreamMetadata",
+        ]
+        assert [s.stream_index for s in metadata.streams] == list(range(6))
+
+    def test_get_container_metadata_reads_no_packets(self):
+        class CountingFileLike:
+            def __init__(self, path):
+                self._file = open(path, "rb")
+                self.bytes_read = 0
+
+            def read(self, size):
+                data = self._file.read(size)
+                self.bytes_read += len(data)
+                return data
+
+            def seek(self, offset, whence):
+                return self._file.seek(offset, whence)
+
+        probed = CountingFileLike(NASA_VIDEO.path)
+        get_container_metadata(probed)
+
+        demuxed = CountingFileLike(NASA_VIDEO.path)
+        list(VideoDemuxer(demuxed))
+
+        assert probed.bytes_read < demuxed.bytes_read
 
     def test_adding_a_stream_after_demuxing_raises(self):
         # Demuxer follows its streams from construction, so this is only

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -81,11 +81,6 @@ def test_get_metadata(metadata_getter):
     assert metadata.best_video_stream_index == 3
     assert metadata.best_audio_stream_index == 4
 
-    with pytest.raises(NotImplementedError, match="Decide on logic"):
-        metadata.duration_seconds
-    with pytest.raises(NotImplementedError, match="Decide on logic"):
-        metadata.bit_rate
-
     if ffmpeg_major_version <= 5:
         expected_duration_seconds_from_header = 16.57
         expected_bit_rate_from_header = 324915
@@ -100,7 +95,6 @@ def test_get_metadata(metadata_getter):
 
     best_video_stream_metadata = metadata.streams[metadata.best_video_stream_index]
     assert isinstance(best_video_stream_metadata, VideoStreamMetadata)
-    assert best_video_stream_metadata is metadata.best_video_stream
     assert best_video_stream_metadata.duration_seconds == pytest.approx(
         13.013, abs=0.001
     )
@@ -118,7 +112,6 @@ def test_get_metadata(metadata_getter):
 
     best_audio_stream_metadata = metadata.streams[metadata.best_audio_stream_index]
     assert isinstance(best_audio_stream_metadata, AudioStreamMetadata)
-    assert best_audio_stream_metadata is metadata.best_audio_stream
     assert best_audio_stream_metadata.duration_seconds_from_header == 13.056
     assert best_audio_stream_metadata.begin_stream_seconds_from_header == 0
     assert best_audio_stream_metadata.bit_rate == 128837
@@ -137,7 +130,6 @@ def test_get_metadata_audio_file(metadata_getter):
     metadata = metadata_getter(NASA_AUDIO_MP3.path)
     best_audio_stream_metadata = metadata.streams[metadata.best_audio_stream_index]
     assert isinstance(best_audio_stream_metadata, AudioStreamMetadata)
-    assert best_audio_stream_metadata is metadata.best_audio_stream
 
     expected_duration_seconds_from_header = (
         13.056 if ffmpeg_major_version >= 8 else 13.248


### PR DESCRIPTION
This exposes the missing metadata tiers in the Blocks APIs, and also exposes a public `get_container_metadata()` util. We now have:

```python
demuxer.metadata              # DemuxerMetadata: the container
demuxer.streams[i].metadata   # Video/AudioStreamHeaderMetadata: one stream's header
video_stream.scan()           # FrameIndex: one stream's content (already existed)

get_container_metadata(source)  # ContainerMetadata: container + every stream
```

**`DemuxerMetadata`** — duration, bit rate, best video/audio index. Container facts only, no stream list, since `demuxer.streams[i].metadata` already describes the streams it follows.

**`ContainerMetadata`** — the same four fields *plus* `streams`: one entry per stream in the file, including subtitle and data ones a demuxer cannot follow. For a caller who doesn't yet know what to ask for. Opens the source and reads only the header, no packets. (`_core._metadata` has a same-named private function, but it takes an open decoder handle rather than a source.)

All three are new to the blocks API, `get_container_metadata` included.

Together, all the fields available via of `demuxer.metadata`, `demuxer.streams[i].metadata`, and `video_stream.scan()` make up what is exposed via `VideoDecoder.metadata` (with scan). The key difference is that the blocks metadata never do any magic fallback - the `VideoDecoder.metadata` does a lot of fallabcks via `@properties` or even in Cpp.

### Implementation

Mostly moved code rather than new code:

- the metadata builder moves out of `SingleStreamDecoder::initialize_decoder()`   into `get_container_metadata_from_format_context()` in `Metadata.cpp` 
- the header-only half of the stream JSON writer is factored out and shared the   same way;
- two new ops read those from a demuxer handle rather than a decoder handle.

Also deletes, all unused: `ContainerMetadata.duration_seconds` / `.bit_rate` (raised `NotImplementedError`), `.best_video_stream` / `.best_audio_stream` (only tests used them; production code uses the `_index` fields), and `SingleStreamDecoder::get_best_stream_index`, which the move left dead.

### What this does not do yet

**You still can't inspect a file and then demux it without opening it twice.**

`get_container_metadata(source)` opens the source; constructing a `Demuxer` opens it again. That second open is a bounded header probe, not a read of the file (~2.6 ms against ~119 ms to decode a 13s clip), so we accept it for now. A
URL is where it would actually hurt.

If we get feature requests for this, we could let `streams=` take a callable, invoked with the container metadata after probing and before following anything. That door stays open, it's additive.