### PR TITLE
Remove single-stream VideoDemuxer and AudioDemuxer

### DIFF
--- a/benchmarks/bench_blocks.py
+++ b/benchmarks/bench_blocks.py
@@ -15,7 +15,7 @@ import psutil
 import torch
 
 from torchcodec.decoders import VideoDecoder
-from torchcodec.decoders._blocks import ColorConverter, VideoDemuxer
+from torchcodec.decoders._blocks import ColorConverter, Demuxer
 
 # Kept minimal on purpose; the filename is derived from exactly these.
 _DURATION_S = 10
@@ -112,16 +112,16 @@ def _consume(frames):
 
 
 def _decode_sequential(path, device="cpu"):
-    demuxer = VideoDemuxer(path)
-    decoder = demuxer.make_decoder(device=device)
+    demuxer = Demuxer(path)
+    decoder = demuxer.streams[0].make_decoder(device=device)
     converter = ColorConverter(device=device)
     _consume(_convert(converter, _decode(decoder, _demux(demuxer))))
 
 
 def _decode_prefetch_frames(path, device="cpu"):
     # [demux + decode] on one thread || [color-convert] on another.
-    demuxer = VideoDemuxer(path)
-    decoder = demuxer.make_decoder(device=device)
+    demuxer = Demuxer(path)
+    decoder = demuxer.streams[0].make_decoder(device=device)
     converter = ColorConverter(device=device)
     frames = prefetch(_decode(decoder, _demux(demuxer)))
     _consume(_convert(converter, frames))
@@ -129,8 +129,8 @@ def _decode_prefetch_frames(path, device="cpu"):
 
 def _decode_prefetch_packets(path, device="cpu"):
     # [demux] on one thread || [decode + color-convert] on another.
-    demuxer = VideoDemuxer(path)
-    decoder = demuxer.make_decoder(device=device)
+    demuxer = Demuxer(path)
+    decoder = demuxer.streams[0].make_decoder(device=device)
     converter = ColorConverter(device=device)
     packets = prefetch(_demux(demuxer))
     _consume(_convert(converter, _decode(decoder, packets)))
@@ -138,8 +138,8 @@ def _decode_prefetch_packets(path, device="cpu"):
 
 def _decode_prefetch_packets_and_frames(path, device="cpu"):
     # [demux] || [decode] || [color-convert], each on its own thread.
-    demuxer = VideoDemuxer(path)
-    decoder = demuxer.make_decoder(device=device)
+    demuxer = Demuxer(path)
+    decoder = demuxer.streams[0].make_decoder(device=device)
     converter = ColorConverter(device=device)
     packets = prefetch(_demux(demuxer))
     frames = prefetch(_decode(decoder, packets))

--- a/examples/decoding/blocks.py
+++ b/examples/decoding/blocks.py
@@ -21,8 +21,8 @@ stages separately:
 
 .. code-block::
 
-   VideoDemuxer  ->  VideoPacketDecoder  ->  ColorConverter
-     Packet            RawFrame               RGB Frame
+   Demuxer  ->  VideoPacketDecoder  ->  ColorConverter
+    Packet         RawFrame               RGB Frame
 
 The blocks are passive: they never create threads, and they release the GIL.
 You decide how they are composed, on which threads, and where to stop. Below
@@ -30,9 +30,9 @@ we illustrate a few things this enables: overlapping stages on multiple
 threads, accessing raw (YUV) frames, and decoding streams of unknown -
 possibly infinite - length.
 
-Audio works the same way, through ``AudioDemuxer``, ``AudioPacketDecoder`` and
-``AudioConverter``; we come back to it at the end, along with ``Demuxer``, which
-gets the audio *and* the video of a container out of a single pass over it.
+Audio works the same way, through ``AudioPacketDecoder`` and
+``AudioConverter``; we come back to it at the end, and to following the audio
+*and* the video of a container in a single pass over it.
 """
 
 # %%
@@ -67,14 +67,20 @@ subprocess.run(
 # it can output a frame, and it buffers a few frames that ``drain()`` returns
 # at the end.
 #
-# ``VideoPacketDecoder`` and ``ColorConverter`` both accept ``device="cuda"``:
+# A ``Demuxer`` follows one or more streams of a container - by default the
+# best video stream - and ``demuxer.streams`` is what it ended up with. A packet
+# decoder is built from one of those streams, which is what binds it to the
+# codec parameters it has to decode with.
+#
+# ``make_decoder()`` and ``ColorConverter`` both accept ``device="cuda"``:
 # decoding then runs on NVDEC and the color conversion on the GPU, and the
 # frames never leave the device. Demuxing always happens on the CPU. Left
 # unspecified, ``device`` is the current default device.
-from torchcodec.decoders._blocks import ColorConverter, VideoDemuxer, VideoPacketDecoder
+from torchcodec.decoders._blocks import ColorConverter, Demuxer
 
-demuxer = VideoDemuxer(video_path)
-packet_decoder = VideoPacketDecoder(demuxer, device=device)
+demuxer = Demuxer(video_path)
+(video_stream,) = demuxer.streams
+packet_decoder = video_stream.make_decoder(device=device)
 color_converter = ColorConverter(device=device)
 
 frames = []
@@ -137,16 +143,16 @@ def prefetch(upstream, buffer_size=8):
 
 def sequential():
     # demux -> decode -> color-convert, all on the calling thread.
-    demuxer = VideoDemuxer(video_path)
-    packet_decoder = VideoPacketDecoder(demuxer, device=device)
+    demuxer = Demuxer(video_path)
+    packet_decoder = demuxer.streams[0].make_decoder(device=device)
     color_converter = ColorConverter(device=device)
     return color_convert(color_converter, decode(packet_decoder, demux(demuxer)))
 
 
 def convert_on_own_thread():
     # [demux + decode] on one thread || [color-convert] on another.
-    demuxer = VideoDemuxer(video_path)
-    packet_decoder = VideoPacketDecoder(demuxer, device=device)
+    demuxer = Demuxer(video_path)
+    packet_decoder = demuxer.streams[0].make_decoder(device=device)
     color_converter = ColorConverter(device=device)
     raw_frames = prefetch(decode(packet_decoder, demux(demuxer)))
     return color_convert(color_converter, raw_frames)
@@ -156,8 +162,8 @@ def demux_on_own_thread():
     # [demux] on one thread || [decode + color-convert] on another. This is the
     # natural split on CUDA: demuxing is CPU and I/O work, while decoding and
     # color conversion both happen on the GPU, so they belong together.
-    demuxer = VideoDemuxer(video_path)
-    packet_decoder = VideoPacketDecoder(demuxer, device=device)
+    demuxer = Demuxer(video_path)
+    packet_decoder = demuxer.streams[0].make_decoder(device=device)
     color_converter = ColorConverter(device=device)
     packets = prefetch(demux(demuxer))
     return color_convert(color_converter, decode(packet_decoder, packets))
@@ -177,15 +183,15 @@ for pipeline in (sequential, convert_on_own_thread, demux_on_own_thread):
 # Seeking
 # -------
 #
-# ``VideoDemuxer.seek()`` moves the demuxer to a timestamp. A decoder can only start
+# ``Demuxer.seek()`` moves the demuxer to a timestamp. A decoder can only start
 # on a keyframe, so the seek lands on the keyframe at or before the target, and
 # the first frames that come out usually precede it: keep decoding forward and
 # drop them until you reach the timestamp you asked for.
 #
 # The seek also invalidates the frames the decoder is holding on to, so the
 # ``VideoPacketDecoder`` must be ``reset()``.
-demuxer = VideoDemuxer(video_path)
-packet_decoder = VideoPacketDecoder(demuxer, device=device)
+demuxer = Demuxer(video_path)
+packet_decoder = demuxer.streams[0].make_decoder(device=device)
 color_converter = ColorConverter(device=device)
 
 seconds = 2.5
@@ -209,7 +215,7 @@ print(f"asked for {seconds}s, landed on {landed_on.pts_seconds:.3f}s, "
 # Scanning
 # --------
 #
-# ``VideoDemuxer.scan()`` demuxes the whole stream once, without decoding anything,
+# ``VideoStream.scan()`` demuxes the whole stream once, without decoding anything,
 # and returns a ``FrameIndex``: one entry per frame, in presentation order.
 # This is the only way to know a stream's exact frame count, timestamps and
 # keyframe positions - a container header can be wrong about all of them. It
@@ -217,9 +223,10 @@ print(f"asked for {seconds}s, landed on {landed_on.pts_seconds:.3f}s, "
 #
 # The ``_from_content`` suffix marks the values the header also claims to know:
 # it is there so that a call site says which of the two sources it trusts.
-demuxer = VideoDemuxer(video_path)
-index = demuxer.scan()
-packet_decoder = VideoPacketDecoder(demuxer, device=device)
+demuxer = Demuxer(video_path)
+(video_stream,) = demuxer.streams
+index = video_stream.scan()
+packet_decoder = video_stream.make_decoder(device=device)
 color_converter = ColorConverter(device=device)
 
 print(f"{index.num_frames_from_content} frames at "
@@ -289,8 +296,8 @@ print(f"frame {i} at {target.pts_seconds:.3f}s")
 #
 # Color conversion is optional. A ``RawFrame`` can hand out the decoder's own
 # planes as tensor views, with no copy and no conversion.
-demuxer = VideoDemuxer(video_path)
-packet_decoder = VideoPacketDecoder(demuxer, device=device)
+demuxer = Demuxer(video_path)
+packet_decoder = demuxer.streams[0].make_decoder(device=device)
 raw_frame = next(decode(packet_decoder, demux(demuxer)))
 
 Y, U, V = raw_frame.planes
@@ -361,8 +368,8 @@ subprocess.run(
     capture_output=True,  # x265 logs its banner to stderr no matter what
 )
 
-hdr_demuxer = VideoDemuxer(hdr_video_path)
-hdr_packet_decoder = VideoPacketDecoder(hdr_demuxer, device=device)
+hdr_demuxer = Demuxer(hdr_video_path)
+hdr_packet_decoder = hdr_demuxer.streams[0].make_decoder(device=device)
 hdr_raw = next(decode(hdr_packet_decoder, demux(hdr_demuxer)))
 
 hdr_Y = hdr_raw.planes[0]
@@ -421,8 +428,8 @@ ffmpeg.wait()
 # %%
 # The blocks just stream it, and we stop whenever we want:
 ffmpeg = start_live_stream()
-demuxer = VideoDemuxer(fifo_path)
-packet_decoder = VideoPacketDecoder(demuxer, device=device)
+demuxer = Demuxer(fifo_path)
+packet_decoder = demuxer.streams[0].make_decoder(device=device)
 color_converter = ColorConverter(device=device)
 
 frames = []
@@ -445,18 +452,14 @@ ffmpeg.wait()
 #
 # .. code-block::
 #
-#    AudioDemuxer  ->  AudioPacketDecoder  ->  AudioConverter
-#      Packet           RawAudioSamples          AudioSamples
+#    Demuxer  ->  AudioPacketDecoder  ->  AudioConverter
+#     Packet        RawAudioSamples          AudioSamples
 #
 # Decoding is the same operation either way, so the two packet decoders are a
 # single class in C++; they are separate in Python because what they hand out
 # isn't. Audio comes out as ``RawAudioSamples``: the codec's own samples, in
 # the codec's own sample type, as a ``[num_channels, num_samples]`` tensor.
-from torchcodec.decoders._blocks import (
-    AudioConverter,
-    AudioDemuxer,
-    AudioPacketDecoder,
-)
+from torchcodec.decoders._blocks import AudioConverter
 
 audio_path = temp_dir / "audio.wav"
 subprocess.run(
@@ -468,8 +471,8 @@ subprocess.run(
     check=True,
 )
 
-demuxer = AudioDemuxer(audio_path)
-packet_decoder = AudioPacketDecoder(demuxer)
+demuxer = Demuxer(audio_path, streams="audio")
+packet_decoder = demuxer.streams[0].make_decoder()
 raw = next(iter(packet_decoder.decode(next(iter(demuxer)))))
 print(f"{raw.sample_format = }, {raw.data.dtype = }, {raw.data.shape = }, "
       f"{raw.sample_rate = }")
@@ -485,8 +488,8 @@ print(f"{raw.sample_format = }, {raw.data.dtype = }, {raw.data.shape = }, "
 # of each frame back until the next one arrives - which is why ``convert()``
 # can return fewer samples than it was given, and why the pipeline ends with
 # ``drain()``. Leave that call out and you lose the end of the stream.
-demuxer = AudioDemuxer(audio_path)
-packet_decoder = AudioPacketDecoder(demuxer)
+demuxer = Demuxer(audio_path, streams="audio")
+packet_decoder = demuxer.streams[0].make_decoder()
 audio_converter = AudioConverter(sample_rate=16_000, num_channels=1)
 
 chunks = []
@@ -508,7 +511,7 @@ print(f"{samples.shape = }, {samples.dtype = }, "
 # stream, and ``scan()`` is what that stream's packets actually say. A name tells
 # you which tier you are reading, so a header value is never mistaken for an
 # exact one:
-demuxer = VideoDemuxer(video_path)
+demuxer = Demuxer(video_path)
 (video,) = demuxer.streams
 
 print(f"container: {demuxer.metadata.duration_seconds_from_header}s")
@@ -537,9 +540,9 @@ for stream in get_container_metadata(video_path).streams:
 # Video and audio together
 # ------------------------
 #
-# ``VideoDemuxer`` and ``AudioDemuxer`` each open their own container, so
-# decoding both streams of one file reads it twice. ``Demuxer`` follows several
-# streams of a single container instead, in one pass.
+# One demuxer per stream means one open container per stream, so decoding both
+# streams of a file that way reads it twice. A single ``Demuxer`` can follow
+# several streams of one container instead, in one pass.
 av_path = temp_dir / "av.mp4"
 subprocess.run(
     [
@@ -554,8 +557,6 @@ subprocess.run(
 # Which streams to follow is said once, at construction: a selector is
 # ``"video"``, ``"audio"`` or a stream index, and ``demuxer.streams`` comes back
 # in the order you asked for. Each stream builds its own decoder.
-from torchcodec.decoders._blocks import Demuxer
-
 demuxer = Demuxer(av_path, streams=("video", "audio"))
 video_stream, audio_stream = demuxer.streams
 

--- a/src/torchcodec/_core/Demuxer.cpp
+++ b/src/torchcodec/_core/Demuxer.cpp
@@ -138,9 +138,7 @@ void Demuxer::find_stream_info() {
   }
 }
 
-void Demuxer::validate_requested_stream(
-    int stream_index,
-    std::optional<AVMediaType> media_type) {
+void Demuxer::validate_requested_stream(int stream_index) {
   int num_streams = static_cast<int>(format_context_->nb_streams);
   STD_TORCH_CHECK(
       stream_index >= 0 && stream_index < num_streams,
@@ -154,34 +152,23 @@ void Demuxer::validate_requested_stream(
 
   AVMediaType stream_media_type =
       format_context_->streams[stream_index]->codecpar->codec_type;
-  if (media_type.has_value()) {
-    STD_TORCH_CHECK(
-        stream_media_type == *media_type,
-        "The stream at index ",
-        stream_index,
-        " is not a ",
-        printable(*media_type),
-        " stream, it is of type '",
-        printable(stream_media_type),
-        "'.");
-  } else {
-    STD_TORCH_CHECK(
-        stream_media_type == AVMEDIA_TYPE_VIDEO ||
-            stream_media_type == AVMEDIA_TYPE_AUDIO,
-        "The stream at index ",
-        stream_index,
-        " is of type '",
-        printable(stream_media_type),
-        "', which cannot be decoded. Only audio and video streams can.");
-  }
+  STD_TORCH_CHECK(
+      stream_media_type == AVMEDIA_TYPE_VIDEO ||
+          stream_media_type == AVMEDIA_TYPE_AUDIO,
+      "The stream at index ",
+      stream_index,
+      " is of type '",
+      printable(stream_media_type),
+      "', which cannot be decoded. Only audio and video streams can.");
 }
 
 std::pair<int, AVMediaType> Demuxer::add_stream(
     std::optional<int> stream_index,
     std::optional<AVMediaType> media_type) {
   STD_TORCH_CHECK(
-      stream_index.has_value() || media_type.has_value(),
-      "A stream must be identified either by its index or by its media type.");
+      stream_index.has_value() != media_type.has_value(),
+      "A stream must be identified by either its index or its media type, "
+      "not both and not neither.");
   STD_TORCH_CHECK(
       !has_demuxed_,
       "Streams must all be added before the first packet is demuxed: a stream "
@@ -190,7 +177,7 @@ std::pair<int, AVMediaType> Demuxer::add_stream(
 
   int index;
   if (stream_index.has_value()) {
-    validate_requested_stream(*stream_index, media_type);
+    validate_requested_stream(*stream_index);
     index = *stream_index;
   } else {
     index = av_find_best_stream(

--- a/src/torchcodec/_core/Demuxer.h
+++ b/src/torchcodec/_core/Demuxer.h
@@ -75,10 +75,9 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
   explicit Demuxer(std::unique_ptr<AVIOContextHolder> avio_context_holder);
 
   // Starts following a stream, and returns its index (absolute across all
-  // media types) together with its media type. Identify it either by
-  // `stream_index`, in which case its media type is looked up and must be audio
-  // or video, or by `media_type` alone, which follows the best stream of that
-  // type. Passing both follows that stream and requires it to be of that type.
+  // media types) together with its media type. Identify it by exactly one of
+  // `stream_index`, whose media type is then looked up and must be audio or
+  // video, or `media_type`, which follows the best stream of that type.
   std::pair<int, AVMediaType> add_stream(
       std::optional<int> stream_index = std::nullopt,
       std::optional<AVMediaType> media_type = std::nullopt);
@@ -122,11 +121,8 @@ class FORCE_PUBLIC_VISIBILITY Demuxer {
 
  private:
   void find_stream_info();
-  // Checks `stream_index` is in range, and that it is of `media_type` when one
-  // is given, or audio or video when it isn't.
-  void validate_requested_stream(
-      int stream_index,
-      std::optional<AVMediaType> media_type);
+  // Checks `stream_index` is in range and that it is an audio or video stream.
+  void validate_requested_stream(int stream_index);
   // The stream a seek is resolved against when the caller doesn't name one:
   // simply the first one that was added. A seek is resolved in a single
   // stream's time base and lands on that stream's keyframes, so which one it is

--- a/src/torchcodec/decoders/_blocks/__init__.py
+++ b/src/torchcodec/decoders/_blocks/__init__.py
@@ -26,14 +26,12 @@ and rationale.
 from ._audio_converter import AudioConverter
 from ._color_converter import ColorConverter
 from ._demuxer import (
-    AudioDemuxer,
     # TODO_API_BREAKDOWN DESIGN P1: AudioStream and VideoStream may conflict
     # with the encoder-side classes of the same name. Maybe that's OK?
     AudioStream,
     Demuxer,
     FrameIndex,
     get_container_metadata,
-    VideoDemuxer,
     VideoStream,
 )
 from ._frame import Packet, RawAudioSamples, RawFrame
@@ -44,8 +42,6 @@ __all__ = [
     "get_container_metadata",
     "VideoStream",
     "AudioStream",
-    "VideoDemuxer",
-    "AudioDemuxer",
     "VideoPacketDecoder",
     "AudioPacketDecoder",
     "ColorConverter",

--- a/src/torchcodec/decoders/_blocks/_demuxer.py
+++ b/src/torchcodec/decoders/_blocks/_demuxer.py
@@ -32,7 +32,10 @@ from torchcodec._core.ops import (
     _blocks_demuxer_stream_json_metadata,
 )
 
+from .._decoder_utils import convert_device_to_str
+
 from ._frame import Packet
+from ._packet_decoder import AudioPacketDecoder, VideoPacketDecoder
 
 # TODO_API_BREAKDOWN FEAT PERF Do we want / need to support 'batch-like' APIs
 # were containers are pre-allocated for perf? Like if a user wants to decode
@@ -41,7 +44,7 @@ from ._frame import Packet
 
 @dataclass
 class FrameIndex:
-    """The content of a video stream, as returned by :meth:`VideoDemuxer.scan`.
+    """The content of a video stream, as returned by :meth:`VideoStream.scan`.
 
     One entry per frame, in presentation order. Everything here is derived from
     the packets of the stream rather than from the container header, so the
@@ -132,7 +135,7 @@ class FrameIndex:
 
     # TODO_API_BREAKDOWN DESIGN P1: Still kinda hate this name
     def key_frame_seconds_for(self, seconds: float) -> float:
-        """Timestamp to :meth:`VideoDemuxer.seek` to in order to reach ``seconds``:
+        """Timestamp to :meth:`Demuxer.seek` to in order to reach ``seconds``:
         that of the last :term:`keyframe` which isn't after it.
 
         This is what makes a seek *exact*. FFmpeg resolves a seek against decode
@@ -260,19 +263,17 @@ class VideoStream(_Stream):
             )
         return self._frame_index
 
-    def make_decoder(self, device: str | torch.device | None = None):
-        """Build the :class:`VideoPacketDecoder` for this stream.
+    def make_decoder(
+        self, device: str | torch.device | None = None
+    ) -> VideoPacketDecoder:
+        """Build the :class:`VideoPacketDecoder` for this stream. This is the
+        only way to build one.
 
         ``device`` accepts a string or a ``torch.device``. It defaults to
         ``None``, which means the current default device (see
         ``torch.set_default_device``).
         """
-        # Imported here rather than at module scope: _packet_decoder
-        # imports this module for the types a decoder can be built from,
-        # so a top-level import either way round would be circular.
-        from ._packet_decoder import VideoPacketDecoder
-
-        return VideoPacketDecoder(self, device=device)
+        return VideoPacketDecoder._from_stream(self, convert_device_to_str(device))
 
 
 class AudioStream(_Stream):
@@ -291,15 +292,11 @@ class AudioStream(_Stream):
 
     _media_type = "audio"
 
-    def make_decoder(self):
-        """Build the :class:`AudioPacketDecoder` for this stream. Audio is
-        always decoded on the CPU, so there is no ``device`` parameter."""
-        # Imported here rather than at module scope: _packet_decoder
-        # imports this module for the types a decoder can be built from,
-        # so a top-level import either way round would be circular.
-        from ._packet_decoder import AudioPacketDecoder
-
-        return AudioPacketDecoder(self)
+    def make_decoder(self) -> AudioPacketDecoder:
+        """Build the :class:`AudioPacketDecoder` for this stream. This is the
+        only way to build one. Audio is always decoded on the CPU, so there is
+        no ``device`` parameter."""
+        return AudioPacketDecoder._from_stream(self, "cpu")
 
 
 class Demuxer:
@@ -310,9 +307,9 @@ class Demuxer:
     thread-safe: use one ``Demuxer`` per thread. It streams from the start of
     the container, or from wherever :meth:`seek` left it.
 
-    Following several streams at once is the point: two single-stream demuxers
-    open the container twice, so decoding both the video and the audio of a file
-    reads it twice. Here they come out of a single pass, interleaved in the
+    Following several streams at once is the point: one demuxer per stream means
+    one open container per stream, so decoding both the video and the audio of a
+    file reads it twice. Here they come out of a single pass, interleaved in the
     order the container stores them, and :attr:`Packet.stream_index` says which
     stream each one belongs to::
 
@@ -504,108 +501,6 @@ class Demuxer:
             if packet is None:
                 return
             yield packet
-
-
-class _SingleStreamDemuxer(Demuxer):
-    """Shared machinery for :class:`VideoDemuxer` and :class:`AudioDemuxer`,
-    which are :class:`Demuxer` pinned to one stream of a known media type."""
-
-    _media_type: str
-
-    def __init__(
-        self,
-        source: str | Path | bytes | Tensor | io.RawIOBase | io.BufferedReader,
-        *,
-        stream_index: int | None = None,
-    ):
-        self._handle = create_demuxer(source=source)
-        self._generation = 0
-        # The media type is pinned, and an explicit index has to match it.
-        index, _ = _blocks_demuxer_add_stream(
-            self._handle, stream_index, self._media_type
-        )
-        stream_class = VideoStream if self._media_type == "video" else AudioStream
-        self.streams = (stream_class(self, index),)
-
-
-class VideoDemuxer(_SingleStreamDemuxer):
-    """Demux building block: opens a container and yields the compressed
-    :class:`Packet`\\ s for one video stream. Does no decoding.
-
-    This is :class:`Demuxer` pinned to a single video stream; see it for
-    everything not specific to that.
-
-    Args:
-        source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the video:
-
-            - If ``str``: a local path or a URL to a media file.
-            - If ``Pathlib.path``: a path to a local media file.
-            - If ``bytes`` object or ``torch.Tensor``: the raw encoded data.
-            - If file-like object: we read data from the object on demand. The object must
-              expose the methods `read(self, size: int) -> bytes` and
-              `seek(self, offset: int, whence: int) -> int`. Note that every
-              read has to re-acquire the GIL, so a file-like source doesn't
-              parallelize with the rest of a pipeline as well as the others do.
-        stream_index (int, optional): Specifies which stream in the video to
-            demux packets from. Note that this index is absolute across all
-            media types. It must refer to a video stream; use
-            :class:`AudioDemuxer` for audio. If left unspecified, then the
-            :term:`best stream` is used.
-    """
-
-    _media_type = "video"
-
-    def scan(self) -> FrameIndex:
-        """Demux the entire stream, without decoding it, and return its
-        :class:`FrameIndex`. See :meth:`VideoStream.scan`."""
-        stream = self.streams[0]
-        assert isinstance(stream, VideoStream)  # mypy: pinned by _media_type
-        return stream.scan()
-
-    def make_decoder(self, device: str | torch.device | None = None):
-        """Build the :class:`VideoPacketDecoder` for this stream. See
-        :meth:`VideoStream.make_decoder`."""
-        stream = self.streams[0]
-        assert isinstance(stream, VideoStream)  # mypy: pinned by _media_type
-        return stream.make_decoder(device=device)
-
-
-class AudioDemuxer(_SingleStreamDemuxer):
-    """Demux building block: opens a container and yields the compressed
-    :class:`Packet`\\ s for one audio stream. Does no decoding.
-
-    This is :class:`Demuxer` pinned to a single audio stream; see it for
-    everything not specific to that.
-
-    Unlike :class:`VideoDemuxer` there is no ``scan()``: a :class:`FrameIndex`
-    describes keyframes and frame positions, and audio has neither.
-
-    Args:
-        source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the audio:
-
-            - If ``str``: a local path or a URL to a media file.
-            - If ``Pathlib.path``: a path to a local media file.
-            - If ``bytes`` object or ``torch.Tensor``: the raw encoded data.
-            - If file-like object: we read data from the object on demand. The object must
-              expose the methods `read(self, size: int) -> bytes` and
-              `seek(self, offset: int, whence: int) -> int`. Note that every
-              read has to re-acquire the GIL, so a file-like source doesn't
-              parallelize with the rest of a pipeline as well as the others do.
-        stream_index (int, optional): Specifies which stream in the file to
-            demux packets from. Note that this index is absolute across all
-            media types. It must refer to an audio stream; use
-            :class:`VideoDemuxer` for video. If left unspecified, then the
-            :term:`best stream` is used.
-    """
-
-    _media_type = "audio"
-
-    def make_decoder(self):
-        """Build the :class:`AudioPacketDecoder` for this stream. See
-        :meth:`AudioStream.make_decoder`."""
-        stream = self.streams[0]
-        assert isinstance(stream, AudioStream)  # mypy: pinned by _media_type
-        return stream.make_decoder()
 
 
 def _container_fields(handle: Tensor) -> dict:

--- a/src/torchcodec/decoders/_blocks/_frame.py
+++ b/src/torchcodec/decoders/_blocks/_frame.py
@@ -29,7 +29,7 @@ class _Metadata(NamedTuple):
 class Packet:
     """Opaque, thread-movable handle to a demuxed (compressed) packet.
 
-    Produced by :class:`VideoDemuxer`, consumed by :class:`VideoPacketDecoder`. It wraps a raw
+    Produced by :class:`Demuxer`, consumed by :class:`VideoPacketDecoder`. It wraps a raw
     pointer, so it is only valid within the process that created it (it cannot
     cross a process boundary).
 
@@ -189,8 +189,8 @@ class RawFrame:
 class RawAudioSamples:
     """One decoded audio frame's samples, as the decoder produced them.
 
-    Produced by :class:`VideoPacketDecoder` for an :class:`AudioDemuxer`'s stream,
-    consumed by :class:`AudioConverter`. This is the audio counterpart of
+    Produced by :class:`AudioPacketDecoder`, consumed by
+    :class:`AudioConverter`. This is the audio counterpart of
     :class:`RawFrame`, and like it, nothing has been converted: the samples are
     in the codec's own sample type.
 

--- a/src/torchcodec/decoders/_blocks/_packet_decoder.py
+++ b/src/torchcodec/decoders/_blocks/_packet_decoder.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Generic, TypeVar
+from typing import Generic, TYPE_CHECKING, TypeVar
 
 import torch
 
@@ -19,22 +19,18 @@ from torchcodec._core.ops import (
     _blocks_packet_decoder_send_packet,
 )
 
-from .._decoder_utils import convert_device_to_str
-from ._demuxer import (
-    _SingleStreamDemuxer,
-    _Stream,
-    AudioDemuxer,
-    AudioStream,
-    Demuxer,
-    VideoDemuxer,
-    VideoStream,
-)
 from ._frame import Packet, RawAudioSamples, RawFrame
+
+if TYPE_CHECKING:
+    # Only for the annotation: _demuxer imports this module to build decoders,
+    # so importing it back at runtime would be circular.
+    from ._demuxer import _Stream
 
 
 # TODO_API_BREAKDOWN DOC P1 revisit every single docstring / comments at some point.
 
 _Decoded = TypeVar("_Decoded", RawFrame, RawAudioSamples)
+_Self = TypeVar("_Self", bound="_BasePacketDecoder")
 
 
 class _BasePacketDecoder(Generic[_Decoded]):
@@ -46,21 +42,34 @@ class _BasePacketDecoder(Generic[_Decoded]):
     a decoded frame is turned into, which is :meth:`_receive_ready_frames`.
     """
 
-    def __init__(self, source: _Stream | _SingleStreamDemuxer, device_str: str):
-        # Built from a stream, or from one of the single-stream demuxers, which
-        # stands in for the one stream it follows.
-        stream = source.streams[0] if isinstance(source, Demuxer) else source
-        self._handle = _blocks_create_packet_decoder(
+    _handle: torch.Tensor
+    _drained: bool
+    _generation: int | None
+
+    # *args so that a call with arguments gets the message below rather than a
+    # TypeError about the argument count.
+    def __init__(self, *args, **kwargs) -> None:
+        raise RuntimeError(
+            f"{type(self).__name__} cannot be instantiated directly. Build one "
+            "from the stream whose packets it decodes, with "
+            "stream.make_decoder()."
+        )
+
+    @classmethod
+    def _from_stream(cls: type[_Self], stream: _Stream, device_str: str) -> _Self:
+        decoder = cls.__new__(cls)
+        decoder._handle = _blocks_create_packet_decoder(
             stream._demuxer._handle,
             stream_index=stream.index,
             num_threads=1,
             device=device_str,
         )
-        self._drained = False
+        decoder._drained = False
         # The demuxer position these packets come from. None until the first
         # packet, and again after every reset(), so it is adopted rather than
         # tracked: the decoder never needs a reference back to the demuxer.
-        self._generation: int | None = None
+        decoder._generation = None
+        return decoder
 
     def _receive_ready_frames(self) -> list[_Decoded]:
         raise NotImplementedError
@@ -104,28 +113,18 @@ class _BasePacketDecoder(Generic[_Decoded]):
         self._generation = None
 
 
-# TODO_API_BREAKDOWN DESIGN P1: Can/should we explicitly prevent user
-# instanciation of these?
 class VideoPacketDecoder(_BasePacketDecoder[RawFrame]):
     """Decode building block: turns compressed :class:`Packet`\\ s into decoded
     (YUV) :class:`RawFrame`\\ s.
 
-    Built from a :class:`VideoDemuxer` (for its codec parameters) and stateful
-    (it holds the codec's reference-frame buffer). Passive and *not*
+    Not built directly: it comes from
+    :meth:`~torchcodec.decoders._blocks.VideoStream.make_decoder`, which is what
+    binds it to the stream whose codec parameters it decodes with. It is
+    stateful (it holds the codec's reference-frame buffer), passive, and *not*
     thread-safe: use one ``VideoPacketDecoder`` per thread. FFmpeg's internal
     codec thread count is kept at 1 for now (not exposed); parallelism comes
     from composing blocks on your own threads.
-
-    ``device`` accepts a string or a ``torch.device``. It defaults to ``None``,
-    which means the current default device (see ``torch.set_default_device``).
     """
-
-    def __init__(
-        self,
-        source: VideoStream | VideoDemuxer,
-        device: str | torch.device | None = None,
-    ):
-        super().__init__(source, convert_device_to_str(device))
 
     def _receive_ready_frames(self) -> list[RawFrame]:
         frames = []
@@ -151,18 +150,17 @@ class AudioPacketDecoder(_BasePacketDecoder[RawAudioSamples]):
     """Decode building block: turns compressed :class:`Packet`\\ s into
     :class:`RawAudioSamples`.
 
-    Built from an :class:`AudioDemuxer` (for its codec parameters) and stateful:
-    a lossy codec's overlap-add state means the frames decoded right after a
-    seek are subtly wrong until it re-primes, so ``reset()`` is necessary but
-    not by itself sufficient - see :meth:`AudioDemuxer.seek`. Passive and *not*
+    Not built directly: it comes from
+    :meth:`~torchcodec.decoders._blocks.AudioStream.make_decoder`. It is
+    stateful: a lossy codec's overlap-add state means the frames decoded right
+    after a seek are subtly wrong until it re-primes, so ``reset()`` is
+    necessary but not by itself sufficient - see
+    :meth:`~torchcodec.decoders._blocks.Demuxer.seek`. Passive and *not*
     thread-safe: use one ``AudioPacketDecoder`` per thread.
 
-    There is no ``device`` parameter: audio is always decoded on the CPU, and
-    that doesn't change with ``torch.set_default_device``.
+    Audio is always decoded on the CPU, and that doesn't change with
+    ``torch.set_default_device``.
     """
-
-    def __init__(self, source: AudioStream | AudioDemuxer):
-        super().__init__(source, "cpu")
 
     def _receive_ready_frames(self) -> list[RawAudioSamples]:
         samples = []

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -44,7 +44,6 @@ from torchcodec.decoders import (
 )
 from torchcodec.decoders._blocks import (
     AudioConverter,
-    AudioDemuxer,
     AudioPacketDecoder,
     AudioStream,
     ColorConverter,
@@ -53,7 +52,6 @@ from torchcodec.decoders._blocks import (
     Packet,
     RawAudioSamples,
     RawFrame,
-    VideoDemuxer,
     VideoPacketDecoder,
     VideoStream,
 )
@@ -3643,7 +3641,7 @@ class TestBlocks:
 
     @pytest.mark.parametrize("device", _block_devices())
     def test_block_output_types(self, device):
-        # VideoDemuxer yields Packets, VideoPacketDecoder yields RawFrames, and
+        # Demuxer yields Packets, VideoPacketDecoder yields RawFrames, and
         # ColorConverter yields Frames with the expected shape/dtype.
         demuxer, decoder, converter = self._make_blocks(NASA_VIDEO.path, device)
 
@@ -3724,10 +3722,14 @@ class TestBlocks:
         frames += decoders[video.index].drain()
         samples += decoders[audio.index].drain()
 
-        video_only = VideoDemuxer(NASA_VIDEO.path)
-        expected_frames = list(self._decode(video_only.make_decoder(), video_only))
-        audio_only = AudioDemuxer(NASA_VIDEO.path)
-        expected_samples = list(self._decode(audio_only.make_decoder(), audio_only))
+        video_only = Demuxer(NASA_VIDEO.path, streams="video")
+        expected_frames = list(
+            self._decode(video_only.streams[0].make_decoder(), video_only)
+        )
+        audio_only = Demuxer(NASA_VIDEO.path, streams="audio")
+        expected_samples = list(
+            self._decode(audio_only.streams[0].make_decoder(), audio_only)
+        )
 
         assert len(frames) == len(expected_frames) > 0
         assert len(samples) == len(expected_samples) > 0
@@ -3853,7 +3855,7 @@ class TestBlocks:
         get_container_metadata(probed)
 
         demuxed = CountingFileLike(NASA_VIDEO.path)
-        list(VideoDemuxer(demuxed))
+        list(Demuxer(demuxed))
 
         assert probed.bytes_read < demuxed.bytes_read
 
@@ -3865,7 +3867,7 @@ class TestBlocks:
         demuxer.next_packet()
 
         with pytest.raises(RuntimeError, match="before the first packet"):
-            _blocks_demuxer_add_stream(demuxer._handle, 4, "audio")
+            _blocks_demuxer_add_stream(demuxer._handle, 4)
 
     # The three decode stages, each expressed as a generator that transforms an
     # iterator of inputs into an iterator of outputs. They compose directly (the
@@ -3921,8 +3923,8 @@ class TestBlocks:
 
     @staticmethod
     def _make_blocks(path, device):
-        demuxer = VideoDemuxer(path)
-        decoder = VideoPacketDecoder(demuxer, device=device)
+        demuxer = Demuxer(path)
+        decoder = demuxer.streams[0].make_decoder(device)
         converter = ColorConverter(device=device)
         return demuxer, decoder, converter
 
@@ -4185,8 +4187,8 @@ class TestBlocks:
 
         def assert_first_frame_is_on_default_device():
             # Note the absence of any device parameter.
-            demuxer = VideoDemuxer(NASA_VIDEO.path)
-            decoder = VideoPacketDecoder(demuxer)
+            demuxer = Demuxer(NASA_VIDEO.path)
+            decoder = demuxer.streams[0].make_decoder()
             converter = ColorConverter()
             decoded = next(self._decode(decoder, self._demux(demuxer)))
             assert decoded.planes[0].device.type == device_str
@@ -4642,7 +4644,7 @@ class TestBlocks:
         # that scoping is the point. get_frame_played_at() is the only
         # VideoDecoder API that seeks straight to the timestamp it was given:
         # it turns `seconds` into a pts and hands that to FFmpeg, which is the
-        # same two steps VideoDemuxer.seek() takes, so the match is structural
+        # same two steps Demuxer.seek() takes, so the match is structural
         # rather than a property of these files. Every other API goes through
         # a frame index, which approximate mode derives from the header's
         # average fps and converts back into a pts - a round trip nothing in
@@ -4689,8 +4691,8 @@ class TestBlocks:
         keyframe_index = video_decoder._get_key_frame_indices()[1]
         seconds = video_decoder.get_frame_at(keyframe_index).pts_seconds
 
-        demuxer = VideoDemuxer(NASA_VIDEO.path)
-        decoder = VideoPacketDecoder(demuxer, device=device)
+        demuxer = Demuxer(NASA_VIDEO.path)
+        decoder = demuxer.streams[0].make_decoder(device)
         num_decoded = 0
         for packet in demuxer:  # decode a bit, so frames pile up in the codec
             num_decoded += len(decoder.decode(packet))
@@ -4733,8 +4735,8 @@ class TestBlocks:
     def test_seek_without_converter_reset_raises(self):
         # A seek invalidates the resampler's state too, and the demuxer cannot
         # know the converter exists - so the samples carry the check onward.
-        demuxer = AudioDemuxer(NASA_AUDIO_MP3.path)
-        decoder = demuxer.make_decoder()
+        demuxer = Demuxer(NASA_AUDIO_MP3.path, streams="audio")
+        decoder = demuxer.streams[0].make_decoder()
         converter = AudioConverter(sample_rate=16_000)
 
         converted = False
@@ -5008,8 +5010,8 @@ class TestBlocks:
             # fmt: on
         )
         try:
-            demuxer = VideoDemuxer(fifo_path)
-            decoder = VideoPacketDecoder(demuxer)
+            demuxer = Demuxer(fifo_path)
+            decoder = demuxer.streams[0].make_decoder()
             num_decoded = 0
             for packet in demuxer:  # make sure the stream is really flowing
                 num_decoded += len(decoder.decode(packet))
@@ -5029,8 +5031,8 @@ class TestBlocks:
         # Draining ends the stream as far as the codec is concerned, and it
         # ignores anything sent afterwards. Rather than silently decoding
         # nothing, say so.
-        demuxer = VideoDemuxer(H265_VIDEO.path)
-        decoder = VideoPacketDecoder(demuxer, device=device)
+        demuxer = Demuxer(H265_VIDEO.path)
+        decoder = demuxer.streams[0].make_decoder(device)
         packet = demuxer.next_packet()
         decoder.decode(packet)
         decoder.drain()
@@ -5060,7 +5062,7 @@ class TestBlocks:
         # construction, so the index has to agree with VideoDecoder on
         # everything the pass produces: how many frames there are, when each of
         # them is displayed and for how long, and which ones are keyframes.
-        index = VideoDemuxer(video.path).scan()
+        index = Demuxer(video.path).streams[0].scan()
         video_decoder = VideoDecoder(video.path, seek_mode="exact")
         frames = video_decoder.get_all_frames()
 
@@ -5103,7 +5105,7 @@ class TestBlocks:
         # index_at() looks up which frame is on screen at a timestamp;
         # get_frame_played_at() decodes to find that same frame. They must
         # agree.
-        index = VideoDemuxer(video.path).scan()
+        index = Demuxer(video.path).streams[0].scan()
         video_decoder = VideoDecoder(video.path, seek_mode="exact")
 
         for i in range(len(index) - 1):  # -1: each frame needs its successor
@@ -5129,9 +5131,9 @@ class TestBlocks:
         # become frames, so counting packets would put the index out of step
         # with both the decoder and VideoDecoder.
         video = DISCARD_FIRST_KEYFRAME_VIDEO
-        index = VideoDemuxer(video.path).scan()
+        index = Demuxer(video.path).streams[0].scan()
 
-        assert len(list(VideoDemuxer(video.path))) == 30  # number of packets
+        assert len(list(Demuxer(video.path))) == 30  # number of packets
         assert len(index) == 25  # number of frames
         assert VideoDecoder(video.path, seek_mode="exact").metadata.num_frames == 25
 
@@ -5139,7 +5141,7 @@ class TestBlocks:
     def test_key_frame_seconds_for(self, video):
         # It must return the last keyframe that isn't after the target, with no
         # keyframe left in between.
-        index = VideoDemuxer(video.path).scan()
+        index = Demuxer(video.path).streams[0].scan()
         key_frame_seconds = index.pts_seconds[index.key_frame_indices].tolist()
 
         for i in range(len(index)):
@@ -5157,7 +5159,7 @@ class TestBlocks:
         # list flagged for discard, so it isn't in the index at all and there's
         # nothing to point at. Fall back to the start of the stream, which is
         # where FFmpeg goes looking for it anyway.
-        index = VideoDemuxer(DISCARD_FIRST_KEYFRAME_VIDEO.path).scan()
+        index = Demuxer(DISCARD_FIRST_KEYFRAME_VIDEO.path).streams[0].scan()
         pts_seconds = index.pts_seconds
 
         assert index.key_frame_indices.tolist() == [5, 15]
@@ -5176,7 +5178,7 @@ class TestBlocks:
         # here makes the blocks reproduce the exact one - including on
         # H265_VIDEO, where a plain seek lands past the target
         # (test_seek_to_non_keyframe_can_land_past_target) and this must not.
-        index = VideoDemuxer(video.path).scan()
+        index = Demuxer(video.path).streams[0].scan()
 
         num_targets = 10
 
@@ -5208,10 +5210,10 @@ class TestBlocks:
         # pipeline built on that same demuxer still decodes the whole stream.
         # The decoder needs no reset(): the scan happened before it was fed
         # anything.
-        demuxer = VideoDemuxer(video.path)
-        index = demuxer.scan()
+        demuxer = Demuxer(video.path)
+        index = demuxer.streams[0].scan()
 
-        decoder = VideoPacketDecoder(demuxer, device=device)
+        decoder = demuxer.streams[0].make_decoder(device)
         converter = ColorConverter(device=device)
         frames = list(
             self._convert(converter, self._decode(decoder, self._demux(demuxer)))
@@ -5224,15 +5226,15 @@ class TestBlocks:
     def test_scan_after_demuxing_raises(self):
         # The scan rewinds the container, which would silently desynchronise
         # every decoder already being fed from it.
-        demuxer = VideoDemuxer(NASA_VIDEO.path)
+        demuxer = Demuxer(NASA_VIDEO.path)
         demuxer.next_packet()
 
         with pytest.raises(RuntimeError, match="before any packet is demuxed"):
-            demuxer.scan()
+            demuxer.streams[0].scan()
 
     def test_scan_is_cached(self):
-        demuxer = VideoDemuxer(NASA_VIDEO.path)
-        assert demuxer.scan() is demuxer.scan()
+        (video,) = Demuxer(NASA_VIDEO.path).streams
+        assert video.scan() is video.scan()
 
     def test_scan_rewind_matches_a_fresh_demuxer(self):
         # scan() rewinds with a seek to 0 rather than reopening the container,
@@ -5241,17 +5243,17 @@ class TestBlocks:
         # exactly what a demuxer that never scanned gives.
         video = DISCARD_FIRST_KEYFRAME_VIDEO
 
-        scanned = VideoDemuxer(video.path)
-        scanned.scan()
+        scanned = Demuxer(video.path)
+        scanned.streams[0].scan()
         after_scan = [
             frame.pts_seconds
-            for frame in self._decode(VideoPacketDecoder(scanned), scanned)
+            for frame in self._decode(scanned.streams[0].make_decoder(), scanned)
         ]
 
-        fresh = VideoDemuxer(video.path)
+        fresh = Demuxer(video.path)
         never_scanned = [
             frame.pts_seconds
-            for frame in self._decode(VideoPacketDecoder(fresh), fresh)
+            for frame in self._decode(fresh.streams[0].make_decoder(), fresh)
         ]
 
         assert after_scan == never_scanned
@@ -5330,12 +5332,14 @@ class TestBlocks:
 
     # ===== stream_index =====
 
-    @pytest.mark.parametrize("stream_index", (None, 0, 3))
-    def test_stream_index(self, stream_index):
+    @pytest.mark.parametrize(
+        "selector, stream_index", (("video", None), (0, 0), (3, 3))
+    )
+    def test_stream_index(self, selector, stream_index):
         # nasa_13013.mp4 has two video streams, 0 and 3, of different sizes,
-        # and 3 is the best one, i.e. the one used when nothing is requested.
-        demuxer = VideoDemuxer(NASA_VIDEO.path, stream_index=stream_index)
-        decoder = VideoPacketDecoder(demuxer)
+        # and 3 is the best one, i.e. the one "video" resolves to.
+        demuxer = Demuxer(NASA_VIDEO.path, streams=selector)
+        decoder = demuxer.streams[0].make_decoder()
         converter = ColorConverter()
         got = [
             converter.convert(raw_frame)
@@ -5350,63 +5354,51 @@ class TestBlocks:
         for got_frame, expected_data in zip(got, expected):
             assert_frames_equal(got_frame.data, expected_data)
 
-    @pytest.mark.parametrize("stream_index", (1, 4))  # the mp4's aac streams
-    def test_audio_stream_index_raises(self, stream_index):
-        with pytest.raises(RuntimeError, match="is not a video stream.*'audio'"):
-            VideoDemuxer(NASA_VIDEO.path, stream_index=stream_index)
-
     def test_audio_only_file_raises(self):
         with pytest.raises(RuntimeError, match="No valid video stream found"):
-            VideoDemuxer(NASA_AUDIO_MP3.path)
+            Demuxer(NASA_AUDIO_MP3.path, streams="video")
 
-    @pytest.mark.parametrize("stream_index", (0, 3))  # the mp4's video streams
-    def test_video_stream_index_raises_on_audio_demuxer(self, stream_index):
-        with pytest.raises(RuntimeError, match="is not a audio stream.*'video'"):
-            AudioDemuxer(NASA_VIDEO.path, stream_index=stream_index)
-
-    def test_video_only_file_raises_on_audio_demuxer(self):
+    def test_video_only_file_raises(self):
         with pytest.raises(RuntimeError, match="No valid audio stream found"):
-            AudioDemuxer(H265_VIDEO.path)
+            Demuxer(H265_VIDEO.path, streams="audio")
 
-    def test_non_video_stream_index_raises(self):
-        # Stream 2 of the mp4 is a subtitle stream.
-        with pytest.raises(RuntimeError, match="is not a video stream.*'subtitle'"):
-            VideoDemuxer(NASA_VIDEO.path, stream_index=2)
-
-    # ===== AudioDemuxer =====
+    # ===== audio streams =====
 
     @pytest.mark.parametrize(
         "asset", (NASA_AUDIO_MP3, NASA_AUDIO, SINE_MONO_S32, SINE_16_CHANNEL_S16)
     )
-    def test_audio_demuxer_yields_packets(self, asset):
-        packets = list(AudioDemuxer(asset.path))
+    def test_audio_yields_packets(self, asset):
+        packets = list(Demuxer(asset.path, streams="audio"))
         assert len(packets) > 0
         assert all(isinstance(packet, Packet) for packet in packets)
 
-    def test_audio_demuxer_picks_the_audio_stream_of_a_video_file(self):
-        # nasa_13013.mp4 has video streams (0, 3) and aac streams (1, 4). The
-        # audio and video demuxers see different, non-empty packet streams.
-        num_audio_packets = len(list(AudioDemuxer(NASA_VIDEO.path)))
-        num_video_packets = len(list(VideoDemuxer(NASA_VIDEO.path)))
+    def test_audio_picks_the_audio_stream_of_a_video_file(self):
+        # nasa_13013.mp4 has video streams (0, 3) and aac streams (1, 4).
+        # Following one or the other gives different, non-empty packet streams.
+        num_audio_packets = len(list(Demuxer(NASA_VIDEO.path, streams="audio")))
+        num_video_packets = len(list(Demuxer(NASA_VIDEO.path, streams="video")))
         assert num_audio_packets > 0
         assert num_video_packets > 0
         assert num_audio_packets != num_video_packets
 
-    @pytest.mark.parametrize("stream_index", (None, 1, 4))
-    def test_audio_demuxer_stream_index(self, stream_index):
-        assert len(list(AudioDemuxer(NASA_VIDEO.path, stream_index=stream_index))) > 0
+    @pytest.mark.parametrize("selector", ("audio", 1, 4))
+    def test_audio_stream_selector(self, selector):
+        assert len(list(Demuxer(NASA_VIDEO.path, streams=selector))) > 0
 
     @pytest.mark.parametrize("make_source", _BLOCKS_SOURCES)
-    def test_audio_demuxer_source_kinds(self, make_source):
+    def test_audio_source_kinds(self, make_source):
         # Every source kind demuxes the very same packets as the path does.
-        expected = len(list(AudioDemuxer(NASA_AUDIO_MP3.path)))
-        assert len(list(AudioDemuxer(make_source(NASA_AUDIO_MP3.path)))) == expected
+        expected = len(list(Demuxer(NASA_AUDIO_MP3.path, streams="audio")))
+        got = Demuxer(make_source(NASA_AUDIO_MP3.path), streams="audio")
+        assert len(list(got)) == expected
 
-    def test_audio_demuxer_seek(self):
+    def test_audio_seek(self):
         # Seeking past the start leaves fewer packets to demux.
-        num_packets_from_start = len(list(AudioDemuxer(NASA_AUDIO_MP3.path)))
+        num_packets_from_start = len(
+            list(Demuxer(NASA_AUDIO_MP3.path, streams="audio"))
+        )
 
-        demuxer = AudioDemuxer(NASA_AUDIO_MP3.path)
+        demuxer = Demuxer(NASA_AUDIO_MP3.path, streams="audio")
         demuxer.seek(NASA_AUDIO_MP3.duration_seconds / 2)
         num_packets_after_seek = len(list(demuxer))
 
@@ -5416,8 +5408,10 @@ class TestBlocks:
 
     @staticmethod
     def _decode_audio(asset, stream_index=None, seek_seconds=None):
-        demuxer = AudioDemuxer(asset.path, stream_index=stream_index)
-        decoder = AudioPacketDecoder(demuxer)
+        demuxer = Demuxer(
+            asset.path, streams="audio" if stream_index is None else stream_index
+        )
+        decoder = demuxer.streams[0].make_decoder()
         if seek_seconds is not None:
             demuxer.seek(seek_seconds)
             decoder.reset()
@@ -5531,15 +5525,16 @@ class TestBlocks:
         assert pts == sorted(pts)
         assert pts[0] == pytest.approx(0, abs=1e-6)
 
-    def test_decoder_output_type_follows_the_demuxer(self):
+    def test_decoder_output_type_follows_the_stream(self):
         # The two decoders are one class in C++; the split is a Python-level
         # one, so that each has an exact output type and its own arguments.
-        for demuxer_class, decoder_class, expected_type in (
-            (AudioDemuxer, AudioPacketDecoder, RawAudioSamples),
-            (VideoDemuxer, VideoPacketDecoder, RawFrame),
+        for selector, decoder_class, expected_type in (
+            ("audio", AudioPacketDecoder, RawAudioSamples),
+            ("video", VideoPacketDecoder, RawFrame),
         ):
-            demuxer = demuxer_class(NASA_VIDEO.path)
-            decoder = decoder_class(demuxer)
+            demuxer = Demuxer(NASA_VIDEO.path, streams=selector)
+            decoder = demuxer.streams[0].make_decoder()
+            assert isinstance(decoder, decoder_class)
             # A codec needs more than one packet before it outputs anything.
             decoded = []
             while not decoded:
@@ -5547,8 +5542,9 @@ class TestBlocks:
             assert isinstance(decoded[0], expected_type)
 
     def test_audio_decoder_takes_no_device(self):
+        (audio,) = Demuxer(NASA_AUDIO_MP3.path, streams="audio").streams
         with pytest.raises(TypeError, match="device"):
-            AudioPacketDecoder(AudioDemuxer(NASA_AUDIO_MP3.path), device="cuda")
+            audio.make_decoder(device="cuda")
 
     def test_audio_decoder_mpeg_ps_resync_after_seek(self):
         # Seeking an MPEG program stream lands on a container-level byte
@@ -5558,8 +5554,8 @@ class TestBlocks:
         # exactly as it does to a video one. Without the resync handling this
         # raises "Failed to send packet to decoder" on the very first packet.
         asset = SINE_STEREO_MP2_MPEG_PS
-        demuxer = AudioDemuxer(asset.path)
-        decoder = AudioPacketDecoder(demuxer)
+        demuxer = Demuxer(asset.path, streams="audio")
+        decoder = demuxer.streams[0].make_decoder()
         demuxer.seek(asset.duration_seconds / 2)
         decoder.reset()
 
@@ -5576,8 +5572,8 @@ class TestBlocks:
 
     @staticmethod
     def _convert_audio(asset, drain=True, seek_seconds=None, **converter_kwargs):
-        demuxer = AudioDemuxer(asset.path)
-        decoder = AudioPacketDecoder(demuxer)
+        demuxer = Demuxer(asset.path, streams="audio")
+        decoder = demuxer.streams[0].make_decoder()
         converter = AudioConverter(**converter_kwargs)
 
         raw_chunks = []
@@ -5738,8 +5734,8 @@ class TestBlocks:
         converter = AudioConverter(sample_rate=16_000)
 
         def convert_all(asset):
-            demuxer = AudioDemuxer(asset.path)
-            decoder = AudioPacketDecoder(demuxer)
+            demuxer = Demuxer(asset.path, streams="audio")
+            decoder = demuxer.streams[0].make_decoder()
             chunks = []
             for packet in demuxer:
                 chunks += [converter.convert(raw) for raw in decoder.decode(packet)]
@@ -5795,8 +5791,8 @@ class TestBlocks:
             self._convert_audio(NASA_AUDIO_MP3, sample_rate=16_000)
         ).shape[1]
 
-        demuxer = AudioDemuxer(NASA_AUDIO_MP3.path)
-        decoder = AudioPacketDecoder(demuxer)
+        demuxer = Demuxer(NASA_AUDIO_MP3.path, streams="audio")
+        decoder = demuxer.streams[0].make_decoder()
         converter = AudioConverter(sample_rate=16_000)
         demuxer.seek(seek_seconds)
         decoder.reset()
@@ -5813,25 +5809,19 @@ class TestBlocks:
         assert 0 < samples.shape[1] < num_samples_from_start
         assert chunks[0].pts_seconds == pytest.approx(seek_seconds, abs=0.2)
 
-    @pytest.mark.parametrize(
-        "demuxer_class", (VideoDemuxer, AudioDemuxer), ids=("video", "audio")
-    )
     @pytest.mark.parametrize("stream_index", (-1, 6, 1000))
-    def test_invalid_stream_index_raises(self, demuxer_class, stream_index):
+    def test_invalid_stream_index_raises(self, stream_index):
         with pytest.raises(RuntimeError, match="is not a valid stream"):
-            demuxer_class(NASA_VIDEO.path, stream_index=stream_index)
+            Demuxer(NASA_VIDEO.path, streams=stream_index)
 
-    @pytest.mark.parametrize(
-        "demuxer_class", (VideoDemuxer, AudioDemuxer), ids=("video", "audio")
-    )
-    def test_bad_source_type_raises(self, demuxer_class):
+    def test_bad_source_type_raises(self):
         with pytest.raises(TypeError, match="Unknown source type"):
-            demuxer_class(123)
+            Demuxer(123)
 
         # user mistakenly forgets to specify binary reading when creating a
         # file-like object from open()
         with pytest.raises(TypeError, match="binary reading?"):
-            demuxer_class(open(NASA_VIDEO.path))
+            Demuxer(open(NASA_VIDEO.path))
 
 
 # Small helpers to avoid having to always specify the same skip marks and decode_fn


### PR DESCRIPTION
They don't provide much value over the more general `Demuxer`. We can always put them back if we want to. 