### PR TITLE
Keep only the output dtype config on VideoStreamOptions

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -426,6 +426,7 @@ BetaCudaDeviceInterface::Mode BetaCudaDeviceInterface::mode() const {
 }
 
 void BetaCudaDeviceInterface::initialize_color_conversion(
+    [[maybe_unused]] OutputDtype output_dtype,
     [[maybe_unused]] const VideoStreamOptions& video_stream_options,
     [[maybe_unused]] const std::vector<std::unique_ptr<Transform>>& transforms,
     [[maybe_unused]] const std::optional<FrameDims>& resized_output_dims) {

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -60,6 +60,7 @@ class BetaCudaDeviceInterface : public DeviceInterface {
       const VideoStreamOptions& video_stream_options) override;
 
   void initialize_color_conversion(
+      OutputDtype output_dtype,
       const VideoStreamOptions& video_stream_options,
       const std::vector<std::unique_ptr<Transform>>& transforms,
       const std::optional<FrameDims>& resized_output_dims) override;

--- a/src/torchcodec/_core/ColorConverter.cpp
+++ b/src/torchcodec/_core/ColorConverter.cpp
@@ -47,12 +47,14 @@ void ColorConverter::maybe_initialize_interface(OutputDtype output_dtype) {
   }
 
   VideoStreamOptions options;
-  options.output_dtype = output_dtype;
   options.device = device_;
 
   std::vector<std::unique_ptr<Transform>> no_transforms;
   device_interface_->initialize_color_conversion(
-      options, no_transforms, /*resized_output_dims=*/std::nullopt);
+      output_dtype,
+      options,
+      no_transforms,
+      /*resized_output_dims=*/std::nullopt);
   initialized_output_dtype_ = output_dtype;
 }
 

--- a/src/torchcodec/_core/CpuDeviceInterface.cpp
+++ b/src/torchcodec/_core/CpuDeviceInterface.cpp
@@ -94,14 +94,15 @@ void CpuDeviceInterface::initialize_video_decoding(
 }
 
 void CpuDeviceInterface::initialize_color_conversion(
+    OutputDtype output_dtype,
     const VideoStreamOptions& video_stream_options,
     const std::vector<std::unique_ptr<Transform>>& transforms,
     const std::optional<FrameDims>& resized_output_dims) {
   av_media_type_ = AVMEDIA_TYPE_VIDEO;
   video_stream_options_ = video_stream_options;
+  output_dtype_ = output_dtype;
   resized_output_dims_ = resized_output_dims;
-  output_pixel_format_ =
-      get_output_pixel_format(video_stream_options_.output_dtype);
+  output_pixel_format_ = get_output_pixel_format(output_dtype_);
 
   // We can use swscale when we have a single resize transform.
   // With a single resize, we use swscale twice:
@@ -265,9 +266,8 @@ void CpuDeviceInterface::convert_video_av_frame_to_frame_output(
   torch::stable::Tensor output_tensor;
 
   if (color_conversion_library == ColorConversionLibrary::SWSCALE) {
-    output_tensor =
-        pre_allocated_output_tensor.value_or(allocate_empty_hwc_tensor(
-            output_dims, kStableCPU, video_stream_options_.output_dtype));
+    output_tensor = pre_allocated_output_tensor.value_or(
+        allocate_empty_hwc_tensor(output_dims, kStableCPU, output_dtype_));
 
     auto av_frame_format = static_cast<AVPixelFormat>(av_frame.format);
     SwsConfig sws_config(

--- a/src/torchcodec/_core/CpuDeviceInterface.h
+++ b/src/torchcodec/_core/CpuDeviceInterface.h
@@ -33,6 +33,7 @@ class CpuDeviceInterface : public DeviceInterface {
       const VideoStreamOptions& video_stream_options) override;
 
   virtual void initialize_color_conversion(
+      OutputDtype output_dtype,
       const VideoStreamOptions& video_stream_options,
       const std::vector<std::unique_ptr<Transform>>& transforms,
       const std::optional<FrameDims>& resized_output_dims) override;
@@ -82,6 +83,9 @@ class CpuDeviceInterface : public DeviceInterface {
       const FrameDims& output_dims) const;
 
   VideoStreamOptions video_stream_options_;
+  // Resolved against the source by whoever set up this conversion, so it isn't
+  // on video_stream_options_.
+  OutputDtype output_dtype_ = OutputDtype::UINT8;
   // Default used when color conversion runs standalone (no stream to derive it
   // from, e.g. the ColorConverter block API). initialize_video_decoding()
   // overrides it from the stream when there is one. Its value doesn't matter on

--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -128,12 +128,14 @@ void CudaDeviceInterface::initialize_video_decoding(
   cpu_interface_->initialize_video(
       av_stream,
       av_format_ctx,
+      OutputDtype::UINT8,
       VideoStreamOptions(),
       {},
       /*resizedOutputDims=*/std::nullopt);
 }
 
 void CudaDeviceInterface::initialize_color_conversion(
+    [[maybe_unused]] OutputDtype output_dtype,
     const VideoStreamOptions& video_stream_options,
     [[maybe_unused]] const std::vector<std::unique_ptr<Transform>>& transforms,
     [[maybe_unused]] const std::optional<FrameDims>& resized_output_dims) {

--- a/src/torchcodec/_core/CudaDeviceInterface.h
+++ b/src/torchcodec/_core/CudaDeviceInterface.h
@@ -34,6 +34,7 @@ class CudaDeviceInterface : public DeviceInterface {
       const VideoStreamOptions& video_stream_options) override;
 
   void initialize_color_conversion(
+      OutputDtype output_dtype,
       const VideoStreamOptions& video_stream_options,
       const std::vector<std::unique_ptr<Transform>>& transforms,
       const std::optional<FrameDims>& resized_output_dims) override;

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -63,8 +63,11 @@ class DeviceInterface {
       [[maybe_unused]] const VideoStreamOptions& video_stream_options) {}
 
   // Initialize state needed to color-convert decoded AVFrames into output
-  // tensors.
+  // tensors. `output_dtype` is what the frames are converted to, already
+  // resolved against the source: it is not read off `video_stream_options`,
+  // which only carries the config it was resolved from.
   virtual void initialize_color_conversion(
+      [[maybe_unused]] OutputDtype output_dtype,
       [[maybe_unused]] const VideoStreamOptions& video_stream_options,
       [[maybe_unused]] const std::vector<std::unique_ptr<Transform>>&
           transforms = {},
@@ -76,12 +79,13 @@ class DeviceInterface {
   void initialize_video(
       const AVStream* av_stream,
       const UniqueDecodingAVFormatContext& av_format_ctx,
+      OutputDtype output_dtype,
       const VideoStreamOptions& video_stream_options,
       const std::vector<std::unique_ptr<Transform>>& transforms,
       const std::optional<FrameDims>& resized_output_dims) {
     initialize_video_decoding(av_stream, av_format_ctx, video_stream_options);
     initialize_color_conversion(
-        video_stream_options, transforms, resized_output_dims);
+        output_dtype, video_stream_options, transforms, resized_output_dims);
   }
 
   // Initialize the device with parameters specific to audio decoding. There is

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -436,7 +436,7 @@ void SingleStreamDecoder::add_video_stream(
         active_stream_index_, custom_frame_mappings.value());
   }
 
-  stream_info.video_stream_options.output_dtype = resolve_output_dtype(
+  stream_info.output_dtype = resolve_output_dtype(
       stream_info.video_stream_options.output_dtype_config,
       static_cast<AVPixelFormat>(stream_info.stream->codecpar->format));
 
@@ -485,11 +485,10 @@ void SingleStreamDecoder::add_video_stream(
     transforms_.push_back(std::unique_ptr<Transform>(transform));
   }
 
-  // Pass the resolved options (AUTO -> UINT8/FLOAT32) so the device interface
-  // sees a definite OutputDtype.
   device_interface_->initialize_video(
       stream_info.stream,
       format_context_,
+      stream_info.output_dtype,
       stream_info.video_stream_options,
       transforms_,
       resized_output_dims_);
@@ -628,8 +627,7 @@ FrameBatchOutput SingleStreamDecoder::get_frames_at_indices(
       frame_indices.numel(),
       get_output_dims(),
       video_stream_options.device,
-      device_interface_->get_pre_allocation_dtype(
-          video_stream_options.output_dtype));
+      device_interface_->get_pre_allocation_dtype(stream_info.output_dtype));
 
   auto frame_batch_output_pts_seconds =
       mutable_accessor<double, 1>(frame_batch_output.pts_seconds);
@@ -701,8 +699,7 @@ FrameBatchOutput SingleStreamDecoder::get_frames_in_range(
       num_output_frames,
       get_output_dims(),
       video_stream_options.device,
-      device_interface_->get_pre_allocation_dtype(
-          video_stream_options.output_dtype));
+      device_interface_->get_pre_allocation_dtype(stream_info.output_dtype));
 
   auto frame_batch_output_pts_seconds =
       mutable_accessor<double, 1>(frame_batch_output.pts_seconds);
@@ -844,8 +841,7 @@ FrameBatchOutput SingleStreamDecoder::get_frames_played_in_range(
         0,
         get_output_dims(),
         video_stream_options.device,
-        device_interface_->get_pre_allocation_dtype(
-            video_stream_options.output_dtype));
+        device_interface_->get_pre_allocation_dtype(stream_info.output_dtype));
     frame_batch_output.data =
         maybe_permute_and_convert_dtype(frame_batch_output.data);
     return frame_batch_output;
@@ -892,8 +888,7 @@ FrameBatchOutput SingleStreamDecoder::get_frames_played_in_range(
         num_output_frames,
         get_output_dims(),
         video_stream_options.device,
-        device_interface_->get_pre_allocation_dtype(
-            video_stream_options.output_dtype));
+        device_interface_->get_pre_allocation_dtype(stream_info.output_dtype));
 
     auto frame_batch_output_pts_seconds =
         mutable_accessor<double, 1>(frame_batch_output.pts_seconds);
@@ -945,8 +940,7 @@ FrameBatchOutput SingleStreamDecoder::get_frames_played_in_range(
         num_frames,
         get_output_dims(),
         video_stream_options.device,
-        device_interface_->get_pre_allocation_dtype(
-            video_stream_options.output_dtype));
+        device_interface_->get_pre_allocation_dtype(stream_info.output_dtype));
     auto frame_batch_output_pts_seconds =
         mutable_accessor<double, 1>(frame_batch_output.pts_seconds);
     auto frame_batch_output_duration_seconds =
@@ -1576,8 +1570,7 @@ torch::stable::Tensor SingleStreamDecoder::maybe_permute_and_convert_dtype(
   }
 
   return convert_to_output_dtype(
-      tensor,
-      stream_infos_[active_stream_index_].video_stream_options.output_dtype);
+      tensor, stream_infos_[active_stream_index_].output_dtype);
 }
 
 // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -245,6 +245,10 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
 
     VideoStreamOptions video_stream_options;
     AudioStreamOptions audio_stream_options;
+    // video_stream_options.output_dtype_config resolved against this stream's
+    // pixel format, which we only know once the stream is added. Decoder state
+    // rather than an option: it is worked out here, not asked for.
+    OutputDtype output_dtype = OutputDtype::UINT8;
   };
 
   // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/StreamOptions.h
+++ b/src/torchcodec/_core/StreamOptions.h
@@ -21,12 +21,15 @@ enum ColorConversionLibrary {
   SWSCALE
 };
 
-// The resolved output dtype. Only UINT8 or FLOAT32 — no AUTO.
-// All code downstream of addVideoStream() should use this.
+// What a frame is actually converted to. Derived, never configured: it is
+// resolve_output_dtype(config, source pixel format), so it can only be known
+// once the source is. Passed to whoever converts or allocates; deliberately not
+// a field of VideoStreamOptions, which describes what was asked for rather than
+// what was worked out from it.
 enum class OutputDtype { UINT8, FLOAT32 };
 
-// The user-facing output dtype config, which may include AUTO.
-// AUTO is resolved in addVideoStream() into an OutputDtype.
+// The user-facing output dtype config, resolved into an OutputDtype by
+// resolve_output_dtype().
 // UINT8: Always output uint8 tensors (default, backward compatible). Uses an
 //        8-bit / RGB24 intermediate.
 // FLOAT32: Always output float32 tensors normalized to [0, 1]. Uses a 16-bit /
@@ -62,13 +65,9 @@ struct VideoStreamOptions {
   // Device variant (e.g., "nvdec", "ffmpeg")
   std::string_view device_variant = "default";
 
-  // The user-specified output dtype config. May be AUTO, which gets resolved
-  // in addVideoStream() into outputDtype below.
+  // What the user asked for. Resolving it needs the source's pixel format, so
+  // that happens where the source is known rather than here.
   OutputDtypeConfig output_dtype_config = OutputDtypeConfig::UINT8;
-
-  // Set by addVideoStream() after resolving AUTO. All downstream code should
-  // read this field.
-  OutputDtype output_dtype = OutputDtype::UINT8;
 
   // Encoding options
   std::optional<std::string> codec;


### PR DESCRIPTION
OutputDtype is resolve_output_dtype(config, source pixel format) - derived,
not configured - and VideoStreamOptions held it next to the config it is
derived from. That made the struct half-valid until someone resolved, and
the two users resolved it in ways the shared field couldn't express:
SingleStreamDecoder wrote the answer back into its own options once per
stream, while ColorConverter, which has to resolve per frame because AUTO
"can differ from one frame to the next", fabricated a whole
VideoStreamOptions for the sole purpose of carrying the answer across
initialize_color_conversion().

So make the resolved dtype an argument of initialize_color_conversion(),
the only stage that needs it, and leave VideoStreamOptions with the config
alone - one field, meaningful from the moment it is constructed.
SingleStreamDecoder's once-per-stream answer moves to StreamInfo, where
decoder state belongs.

Worth knowing while reading this: the two resolutions take their pixel
format from different places, the stream header in SingleStreamDecoder and
the frame itself in ColorConverter, so they can disagree. Passing the
resolved value explicitly doesn't fix that, but it does stop a single
struct field from implying they are one thing.

initialize_color_conversion() and initialize_video() both gain a parameter,
which out-of-tree device interfaces will need to follow.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>