### PR TITLE
Rename the image decoders' OutputDtype to ImageOutputDtypeConfig

### DIFF
--- a/src/torchcodec/_core/DecodeAvif.cpp
+++ b/src/torchcodec/_core/DecodeAvif.cpp
@@ -134,7 +134,8 @@ torch::stable::Tensor decode_avif(
   int num_channels = return_rgb ? 3 : 4;
 
   bool output_16 = should_output_uint16(
-      static_cast<OutputDtype>(output_dtype), decoder->image->depth > 8);
+      static_cast<ImageOutputDtypeConfig>(output_dtype),
+      decoder->image->depth > 8);
 
   torch::stable::Tensor output;
   uint8_t* output_ptr = nullptr;

--- a/src/torchcodec/_core/DecodeHeic.cpp
+++ b/src/torchcodec/_core/DecodeHeic.cpp
@@ -161,7 +161,7 @@ torch::stable::Tensor decode_heic(
       // *widen* an 8-bit source to 16 bits: that would be a lossy 8->10->16
       // hop, so 8->16 is done exactly as `* 257` in Python instead.
       bool output_16 = should_output_uint16(
-          static_cast<OutputDtype>(output_dtype), source_gt_8bit);
+          static_cast<ImageOutputDtypeConfig>(output_dtype), source_gt_8bit);
       decode_16 = source_gt_8bit && output_16;
 
       constexpr bool little_endian = std::endian::native == std::endian::little;

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -122,7 +122,7 @@ PngHeader read_header_and_configure(
     ErrorCtx& error_ctx,
     SourceCtx& source_ctx,
     ImageReadMode read_mode,
-    OutputDtype output_dtype) {
+    ImageOutputDtypeConfig output_dtype) {
   if (setjmp(png_jmpbuf(png_ptr)) != 0) {
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     STD_TORCH_CHECK(false, "decode_png failed: ", error_ctx.error_message);
@@ -368,7 +368,7 @@ torch::stable::Tensor decode_png(
       error_ctx,
       source_ctx,
       static_cast<ImageReadMode>(mode),
-      static_cast<OutputDtype>(output_dtype));
+      static_cast<ImageOutputDtypeConfig>(output_dtype));
 
   auto output_16 = header.output_16;
   output = torch::stable::empty(

--- a/src/torchcodec/_core/ImageCommon.h
+++ b/src/torchcodec/_core/ImageCommon.h
@@ -29,7 +29,12 @@ enum class ImageReadMode : int64_t {
 // relevant for the decoders whose source can carry more than 8 bits per channel
 // (PNG, AVIF, HEIC); AUTO keeps the source's native precision (16-bit for
 // >8-bit sources, 8-bit otherwise).
-enum class OutputDtype : int64_t {
+//
+// The image counterpart of OutputDtypeConfig (StreamOptions.h), which the video
+// side resolves in the same way against its own source. The two aren't shared
+// because the dtypes they choose between differ: uint8/uint16 here against
+// uint8/float32 there.
+enum class ImageOutputDtypeConfig : int64_t {
   UINT8 = 0,
   UINT16 = 1,
   AUTO = 2,
@@ -39,20 +44,20 @@ enum class OutputDtype : int64_t {
 // requeted dtype, and the source. This is assumed to be called on a decoder
 // that supports >8bit sources.
 inline bool should_output_uint16(
-    OutputDtype output_dtype,
+    ImageOutputDtypeConfig output_dtype_config,
     bool source_gt_8bit) {
-  switch (output_dtype) {
-    case OutputDtype::UINT8:
+  switch (output_dtype_config) {
+    case ImageOutputDtypeConfig::UINT8:
       return false;
-    case OutputDtype::UINT16:
+    case ImageOutputDtypeConfig::UINT16:
       return true;
-    case OutputDtype::AUTO:
+    case ImageOutputDtypeConfig::AUTO:
       return source_gt_8bit;
     default:
       STD_TORCH_CHECK(
           false,
           "Unexpected output_dtype ",
-          static_cast<int64_t>(output_dtype),
+          static_cast<int64_t>(output_dtype_config),
           ". This should never happen, please report a bug to the TorchCodec repo.");
   }
 }


### PR DESCRIPTION
ImageCommon.h declared facebook::torchcodec::OutputDtype {UINT8, UINT16,
AUTO} and StreamOptions.h declares facebook::torchcodec::OutputDtype
{UINT8, FLOAT32}: two different types with one fully-qualified name. They
compile today only because no translation unit includes both headers - the
image decoders are FFmpeg-free and pull in neither StreamOptions.h nor
FFMPEGCommon.h nor Frame.h - which makes it a trap for whoever first makes
those worlds touch.

The image one is the odd name rather than the odd type: it carries AUTO and
is resolved at the point of use by should_output_uint16(), so it is a
config, and it is the counterpart of OutputDtypeConfig rather than of
OutputDtype. The int64 codes crossing the op boundary are unchanged, so
_validate_output_dtype on the Python side needs nothing.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>