### PR TITLE
Remove CUDA 12.6 from CI

### DIFF
--- a/.github/workflows/linux_cuda_aarch64_wheel.yaml
+++ b/.github/workflows/linux_cuda_aarch64_wheel.yaml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10']
-        cuda-version: ['12.6']
+        cuda-version: ['13.0']
         ffmpeg-version-for-tests: ['4', '5', '6', '7', '8', '9']
     container:
       image: "pytorch/manylinuxaarch64-builder:cuda${{ matrix.cuda-version }}"

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -68,9 +68,10 @@ jobs:
           # For the actual release we should add that label and change this to
           # include more python versions.
         python-version: ['3.10']
-        # We test against 12.6 and 13.0 to avoid having too big of a CI matrix,
-        # but for releases we should add 12.8.
-        cuda-version: ['12.6', '13.0']
+        # We only test against a subset of the CUDA versions we build for, to
+        # avoid having too big of a CI matrix. For releases we should add the
+        # remaining ones.
+        cuda-version: ['13.0', '13.2']
         # TODO: put back ffmpeg 5 https://github.com/pytorch/torchcodec/issues/325
         ffmpeg-version-for-tests: ['4', '6', '7', '8', '9']
 
@@ -124,16 +125,14 @@ jobs:
       - name: Install torchcodec from the wheel
         run: ${CONDA_RUN} bash packaging/install_torchcodec_wheel.sh "*cu${{ env.cuda_version_without_periods }}-cp${{ env.python_version_without_periods }}*.whl"
 
-      # We skip installing libheif in cases where conda refuses to solve:
-      # - FFmpeg 4 and 5 pin old aom/svt-av1 that conda's libheif can't satisfy.
-      # - CUDA 12.6, for whatever confusing and annoying reason.
-      # HEIC is CPU-only anyway *and* it's still covered on the remaining CUDA 13
-      # jobs (FFmpeg 6/7/8/9), so this loses no real coverage.
+      # We skip installing libheif with FFmpeg 4 and 5: they pin old aom/svt-av1
+      # that conda's libheif can't satisfy. HEIC is CPU-only anyway *and* it's
+      # still covered on the FFmpeg 6/7/8/9 jobs, so this loses no real coverage.
       - name: Install test dependencies
-        run: ${CONDA_RUN} bash packaging/install_test_dependencies.sh ${{ matrix.ffmpeg-version-for-tests != '4' && matrix.ffmpeg-version-for-tests != '5' && matrix.cuda-version != '12.6' }}
+        run: ${CONDA_RUN} bash packaging/install_test_dependencies.sh ${{ matrix.ffmpeg-version-for-tests != '4' && matrix.ffmpeg-version-for-tests != '5' }}
       - name: Run Python tests
         run: |
-          if [ "${{ matrix.ffmpeg-version-for-tests }}" = "4" ] || [ "${{ matrix.ffmpeg-version-for-tests }}" = "5" ] || [ "${{ matrix.cuda-version }}" = "12.6" ]; then export FAIL_WITHOUT_HEIC=0; fi
+          if [ "${{ matrix.ffmpeg-version-for-tests }}" = "4" ] || [ "${{ matrix.ffmpeg-version-for-tests }}" = "5" ]; then export FAIL_WITHOUT_HEIC=0; fi
           ${CONDA_RUN} python packaging/assert_ffmpeg_version.py ${{ matrix.ffmpeg-version-for-tests }}
           ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 FAIL_WITHOUT_IMAGE_CODECS=1 pytest --override-ini="addopts=-v" test --tb=short
       - name: Run Python benchmark
@@ -151,7 +150,7 @@ jobs:
     needs: build
     env:
       PYTHON_VERSION: '3.10'
-      CUDA_VERSION: '12.6'
+      CUDA_VERSION: '13.0'
       FFMPEG_VERSION: '7'
     steps:
       - name: Setup env vars
@@ -213,7 +212,7 @@ jobs:
     needs: build
     env:
       PYTHON_VERSION: '3.10'
-      CUDA_VERSION: '12.6'
+      CUDA_VERSION: '13.0'
     steps:
       - name: Setup env vars
         run: |
@@ -268,10 +267,10 @@ jobs:
     runs-on: linux.g5.4xlarge.nvidia.gpu
     env:
       PYTHON_VERSION: '3.10'
-      CUDA_VERSION: '12.6'
+      CUDA_VERSION: '13.0'
       FFMPEG_VERSION: '7'
     container:
-      image: "pytorch/manylinux2_28-builder:cuda12.6"  # must be same as env!!
+      image: "pytorch/manylinux2_28-builder:cuda13.0"  # must be same as env!!
       options: "--gpus all -e NVIDIA_DRIVER_CAPABILITIES=video,compute,utility"
     needs: build
     steps:

--- a/.github/workflows/windows_cuda_wheel.yaml
+++ b/.github/workflows/windows_cuda_wheel.yaml
@@ -75,7 +75,7 @@ jobs:
           # For the actual release we should add that label and change this to
           # include more python versions.
         python-version: ['3.10']
-        cuda-version: ['12.6', '13.0']
+        cuda-version: ['13.0', '13.2']
         # TODO: FFmpeg 5 on Windows segfaults in avcodec_open2() when passing
         # bad parameters.
         # See https://github.com/pytorch/torchcodec/pull/806
@@ -164,7 +164,7 @@ jobs:
     needs: build
     env:
       PYTHON_VERSION: '3.10'
-      CUDA_VERSION: '12.6'
+      CUDA_VERSION: '13.0'
       FFMPEG_VERSION: '7'
     steps:
       - name: Setup env vars

--- a/packaging/install_pytorch.sh
+++ b/packaging/install_pytorch.sh
@@ -32,24 +32,6 @@ else
   CHANNEL=nightly
 fi
 
-# TEMPORARY, TO BE DELETED once pytorch stops swallowing our IndexErrors.
-# https://github.com/pytorch/pytorch/pull/193451 routes torch.ops.* calls
-# through torch's own exception translation, which turns the std::out_of_range
-# we raise in C++ into a RuntimeError instead of the IndexError that pybind11's
-# default translator produced. Pin to the last nightly before that landed.
-NIGHTLY_PIN=dev20260826
-if [[ $CHANNEL = nightly ]]; then
-  PINNED_PACKAGES=""
-  for package in $PACKAGES; do
-    case "$package" in
-      torch) package="torch==2.15.0.${NIGHTLY_PIN}" ;;
-      torchvision) package="torchvision==0.30.0.${NIGHTLY_PIN}" ;;
-    esac
-    PINNED_PACKAGES="${PINNED_PACKAGES} ${package}"
-  done
-  PACKAGES="$PINNED_PACKAGES"
-fi
-
 echo "Installing PyTorch packages: $PACKAGES"
 echo "Compute platform: $COMPUTE_PLATFORM"
 echo "Channel: $CHANNEL"

--- a/packaging/update_ci_for_release.sh
+++ b/packaging/update_ci_for_release.sh
@@ -34,7 +34,7 @@ for f in "${WHEEL_FILES[@]}"; do
     echo "Updating matrix versions in $f ..."
     sed -i "s|python-version: \[.*\]|python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']|g" "$f"
     sed -i "s|ffmpeg-version-for-tests: \[.*\]|ffmpeg-version-for-tests: ['4', '5', '6', '7', '8', '9']|g" "$f"
-    sed -i "s|cuda-version: \[.*\]|cuda-version: ['12.6', '13.0', '13.2']|g" "$f"
+    sed -i "s|cuda-version: \[.*\]|cuda-version: ['13.0', '13.2']|g" "$f"
 done
 
 echo "Done! Updated workflow files to point to test-infra branch '${BRANCH}'"


### PR DESCRIPTION
torch 2.15 won't come with CUDA 12.6 support, so we have to remove it from our CI / builds. Ref: https://github.com/pytorch/pytorch/issues/190385