### PR TITLE
Add TORCHCODEC_USE_SYSTEM_LIBAVIF option to link the system libavif

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ TORCHCODEC_BUILD_GIF = {env = "TORCHCODEC_BUILD_GIF", default = "AUTO"}
 TORCHCODEC_BUILD_HEIC = {env = "TORCHCODEC_BUILD_HEIC", default = "AUTO"}
 TORCHCODEC_BUILD_NVJPEG = {env = "TORCHCODEC_BUILD_NVJPEG", default = "AUTO"}
 
+# Set to ON to link against a system-provided libavif (located with CMake's
+# find_package) instead of fetching the decode-only prebuilt libavif from S3.
+TORCHCODEC_USE_SYSTEM_LIBAVIF = {env = "TORCHCODEC_USE_SYSTEM_LIBAVIF", default = "OFF"}
+
 [project.optional-dependencies]
 dev = [
     "numpy",

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -49,6 +49,13 @@ foreach(_codec JPEG PNG WEBP AVIF GIF HEIC NVJPEG)
     endif()
 endforeach()
 
+# Packagers building against a system-provided libavif (Linux distros,
+# conda-forge, ...) can set this to ON to use find_package(libavif) instead of
+# fetching the decode-only prebuilt libavif from our S3 bucket.
+if(NOT DEFINED TORCHCODEC_USE_SYSTEM_LIBAVIF)
+    set(TORCHCODEC_USE_SYSTEM_LIBAVIF "OFF")
+endif()
+
 # Returns true (via out_want) if TORCHCODEC_BUILD_IMAGE is on, or if that
 # specific codec flag is explicitly on, and false otherwise.
 function(resolve_image_codec codec_flag out_want)
@@ -139,9 +146,16 @@ function(discover_image_codecs)
 
     resolve_image_codec("${TORCHCODEC_BUILD_AVIF}" want_avif)
     if(want_avif)
-        include(${CMAKE_CURRENT_SOURCE_DIR}/fetch_avif_from_s3.cmake)
-        set(libavif_FOUND TRUE)
-        message(STATUS "Building torchcodec with AVIF image decoding support (libavif from S3).")
+        if(TORCHCODEC_USE_SYSTEM_LIBAVIF)
+            # Link the system libavif instead of the decode-only prebuilt from
+            # S3, mirroring how the HEIC decoder uses the system libheif below.
+            find_package(libavif CONFIG REQUIRED)
+            message(STATUS "libavif found: building torchcodec with AVIF image decoding support (system libavif).")
+        else()
+            include(${CMAKE_CURRENT_SOURCE_DIR}/fetch_avif_from_s3.cmake)
+            set(libavif_FOUND TRUE)
+            message(STATUS "Building torchcodec with AVIF image decoding support (libavif from S3).")
+        endif()
     else()
         message(STATUS "Not building torchcodec with AVIF image decoding support (disabled via TORCHCODEC_BUILD_AVIF/TORCHCODEC_BUILD_IMAGE): decode_avif will raise at runtime.")
     endif()


### PR DESCRIPTION
AVIF support currently always fetches a decode-only prebuilt libavif from S3. That is the right default for the self-contained wheels, but it does not work for downstream redistributors without prebuilt binary.

This fix mirroring how the HEIC decoder already uses the system libheif. The default stays OFF, so wheel builds are unaffected.

Tested on Arch Linux loong64 with libavif 1.4.2, all the test suites passes.